### PR TITLE
handle xml mangling of repeated elements (#55)

### DIFF
--- a/stubo/ext/xmlutils.py
+++ b/stubo/ext/xmlutils.py
@@ -29,7 +29,7 @@ class XPathValue(Value):
         
         :Params:
           - `xpath`: XPATH expression to locate an one or more XML elements or attributes.  An instance of :class:`string`
-          - `extractor`  (optional): functor that can be used to transform the result of the XPATH value. Called with a single arg which is the XPATH result text of the first match (xpath_result[0].text). e.g. extractor=lambda x: x.upper()
+          - `extractor`  (optional): functor that can be used to transform the result of the XPATH value. Called with a single arg which is the XPATH result text of the corresponding matching element (xpath_result[X].text). e.g. extractor=lambda x: x.upper()
           - `name` (optional): element name to use, defaults to basename(xpath)
         """  
         self.xpath = xpath

--- a/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/all.commands
+++ b/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/all.commands
@@ -1,0 +1,9 @@
+delete/stubs?scenario=embedded&force=true
+put/module?name=/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.py
+begin/session?scenario=embedded&session=embedded_rec&mode=record
+put/stub?session=embedded_rec&ext_module=embedded,embedded.request.xml,embedded.response.xml
+end/session?session=embedded_rec
+
+begin/session?scenario=embedded&session=embedded_play&mode=playback
+get/response?session=embedded_play,embedded.request2.xml
+end/session?session=embedded_play

--- a/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.py
+++ b/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.py
@@ -1,0 +1,27 @@
+import logging
+from stubo.ext.xmlutils import XPathValue
+from stubo.ext.xmlexit import XMLManglerExit
+
+log = logging.getLogger(__name__)
+
+# remove date from <Command> values
+"""
+<X>
+    <Command>FQC1GBP/EUR/20Oct14</Command>
+    <Command>FQC1USD/USD/25Oct14</Command>
+</X>
+"""        
+
+elements = dict(screen_query=XPathValue('//X/Command', extractor=lambda x: x[:-7]))
+
+    
+exit = XMLManglerExit(elements=elements)
+    
+def exits(request, context):
+    return exit.get_exit(request, context)
+    
+
+
+        
+
+

--- a/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.request.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.request.xml
@@ -1,0 +1,4 @@
+<X>
+    <Command>FQC1GBP/EUR/20Oct14</Command>
+    <Command>FQC1USD/USD/20Oct15</Command>
+</X>

--- a/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.request2.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.request2.xml
@@ -1,0 +1,4 @@
+<X>
+    <Command>FQC1GBP/EUR/25Oct14</Command>
+    <Command>FQC1USD/USD/25Oct15</Command>
+</X>

--- a/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.response.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.response.xml
@@ -1,0 +1,3 @@
+<response>
+<a>my response is kind</a>
+</response>

--- a/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/play.commands
+++ b/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/play.commands
@@ -1,0 +1,3 @@
+begin/session?scenario=embedded&session=embedded_play&mode=playback
+get/response?session=embedded_play,embedded.request2.xml
+end/session?session=embedded_play

--- a/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/record.commands
+++ b/stubo/static/cmds/tests/ext/auto_mangle/embedded_multiple/record.commands
@@ -1,0 +1,5 @@
+delete/stubs?scenario=embedded&force=true
+put/module?name=/static/cmds/tests/ext/auto_mangle/embedded_multiple/embedded.py
+begin/session?scenario=embedded&session=embedded_rec&mode=record
+put/stub?session=embedded_rec&ext_module=embedded,embedded.request.xml,embedded.response.xml
+end/session?session=embedded_rec

--- a/stubo/static/cmds/tests/ext/auto_mangle/response/response.py
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response/response.py
@@ -8,9 +8,8 @@ def roll_dt(date_str):
     # roll date part of string
     date_str = date_str.strip()
     return "{{% raw roll_date('{0}', as_date(recorded_on), as_date(played_on)) %}}".format(date_str)
-                                                 
-element_index_func = 'position() - 1'   
-response_elements = dict(a=XPathValue('//response/b', extractor=lambda x: '{% raw getresponse_arg %}', element_index_func=element_index_func),
+                                                    
+response_elements = dict(a=XPathValue('//response/b', extractor=lambda x: '{% raw getresponse_arg %}'),
                          b=XPathValue('//response/c', extractor=lambda x: "{{xmltree.xpath('/request/dt')[0].text}}"),
                          dt=XPathValue('//user:dt', extractor=roll_dt),
                          userid=XPathValue('//user:InformationSystemUserIdentity/info:UserId',

--- a/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/all.commands
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/all.commands
@@ -1,0 +1,11 @@
+delete/stubs?scenario=response&force=true
+put/module?name=/static/cmds/tests/ext/auto_mangle/response_multiple/response.py
+begin/session?scenario=response&session=response_rec&mode=record
+put/stub?session=response_rec&ext_module=response&recorded_on=2014-12-10,response.request.xml,response.response.xml
+put/stub?session=response_rec&ext_module=response&recorded_on=2014-12-10,response.request2.xml,response.response_ns.xml
+end/session?session=response_rec
+
+begin/session?scenario=response&session=response_play&mode=playback
+get/response?session=response_play&ext_module=response&played_on=2014-12-15&getresponse_arg=foo,response.request.xml
+get/response?session=response_play&ext_module=response&played_on=2014-12-15,response.request2.xml
+end/session?session=response_play

--- a/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/play.commands
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/play.commands
@@ -1,0 +1,4 @@
+begin/session?scenario=response&session=response_play&mode=playback
+get/response?session=response_play&ext_module=response&played_on=2014-12-15&getresponse_arg=foo,response.request.xml
+get/response?session=response_play&ext_module=response&played_on=2014-12-15,response.request2.xml
+end/session?session=response_play

--- a/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/record.commands
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/record.commands
@@ -1,0 +1,6 @@
+delete/stubs?scenario=response&force=true
+put/module?name=/static/cmds/tests/ext/auto_mangle/response_multiple/response.py
+begin/session?scenario=response&session=response_rec&mode=record
+put/stub?session=response_rec&ext_module=response&recorded_on=2014-12-10,response.request.xml,response.response.xml
+put/stub?session=response_rec&ext_module=response&recorded_on=2014-12-10,response.request2.xml,response.response_ns.xml
+end/session?session=response_rec

--- a/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.py
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.py
@@ -9,10 +9,10 @@ def roll_dt(date_str):
     date_str = date_str.strip()
     return "{{% raw roll_date('{0}', as_date(recorded_on), as_date(played_on)) %}}".format(date_str)
                                                     
-response_elements = dict(a=XPathValue('//response/b', extractor=lambda x: '{% raw getresponse_arg %}', element_index_func='position() - 1'),
+response_elements = dict(a=XPathValue('//response/b', extractor=lambda x: '{% raw getresponse_arg %}'),
                          b=XPathValue('//response/c', extractor=lambda x: "{{xmltree.xpath('/request/dt')[0].text}}"),
-                         info_date=XPathValue('//response/info/date', extractor=roll_dt, element_index_func='count(../preceding-sibling::info) + 1'),
-                         dt=XPathValue('//user:dt', extractor=roll_dt, element_index_func='count(../preceding-sibling::user:Body) + 1'),
+                         info_date=XPathValue('//response/info/date', extractor=roll_dt),
+                         dt=XPathValue('//user:dt', extractor=roll_dt),
                          userid=XPathValue('//user:InformationSystemUserIdentity/info:UserId',
                                            extractor=lambda x: "{{xmltree.xpath('/request2/user')[0].text}}"))
     

--- a/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.py
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.py
@@ -8,11 +8,11 @@ def roll_dt(date_str):
     # roll date part of string
     date_str = date_str.strip()
     return "{{% raw roll_date('{0}', as_date(recorded_on), as_date(played_on)) %}}".format(date_str)
-                                                 
-element_index_func = 'position() - 1'   
-response_elements = dict(a=XPathValue('//response/b', extractor=lambda x: '{% raw getresponse_arg %}', element_index_func=element_index_func),
+                                                    
+response_elements = dict(a=XPathValue('//response/b', extractor=lambda x: '{% raw getresponse_arg %}', element_index_func='position() - 1'),
                          b=XPathValue('//response/c', extractor=lambda x: "{{xmltree.xpath('/request/dt')[0].text}}"),
-                         dt=XPathValue('//user:dt', extractor=roll_dt),
+                         info_date=XPathValue('//response/info/date', extractor=roll_dt, element_index_func='count(../preceding-sibling::info) + 1'),
+                         dt=XPathValue('//user:dt', extractor=roll_dt, element_index_func='count(../preceding-sibling::user:Body) + 1'),
                          userid=XPathValue('//user:InformationSystemUserIdentity/info:UserId',
                                            extractor=lambda x: "{{xmltree.xpath('/request2/user')[0].text}}"))
     

--- a/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.request.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.request.xml
@@ -1,0 +1,4 @@
+<request>
+<dt>2014-12-25</dt>
+<user>fred</user>
+</request>

--- a/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.request2.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.request2.xml
@@ -1,0 +1,4 @@
+<request2>
+<dt>2014-12-25</dt>
+<user>fred</user>
+</request2>

--- a/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.response.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.response.xml
@@ -1,0 +1,8 @@
+<response>
+<a>hello</a>
+<b>goodbye</b>
+<b>au revoir</b>
+<c>2014-12-01</c>
+<info><date>2014-12-01</date></info>
+<info><date>2015-12-01</date></info>
+</response>

--- a/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.response_ns.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/response_multiple/response.response_ns.xml
@@ -1,0 +1,16 @@
+ <?xml version="1.0" encoding="UTF-8" ?>
+<user:Response xmlns:user="http://www.my.com/userschema"
+	xmlns:info="http://www.my.com/infoschema">
+	<user:Body>
+		<user:dt>2014-12-10T15:30</user:dt>
+		<user:InformationSystemUserIdentity>
+			<info:UserId>joe</info:UserId>
+		</user:InformationSystemUserIdentity>
+	</user:Body>
+	<user:Body>
+		<user:dt>2015-12-10T15:30</user:dt>
+		<user:InformationSystemUserIdentity>
+			<info:UserId>joe</info:UserId>
+		</user:InformationSystemUserIdentity>
+	</user:Body>
+</user:Response>

--- a/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/all.commands
+++ b/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/all.commands
@@ -1,0 +1,10 @@
+put/module?name=/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/ignore.py
+delete/stubs?scenario=ignore_xml&force=true
+
+begin/session?scenario=ignore_xml&session=ignore_xml1&mode=record
+put/stub?session=ignore_xml1&ext_module=ignore&tracking_level=full, matcher.xml, response.xml
+end/session?session=ignore_xml1
+
+begin/session?scenario=ignore_xml&session=ignore_xml1&mode=playback
+get/response?session=ignore_xml1&tracking_level=full, request.xml
+end/session?session=ignore_xml1

--- a/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/ignore.py
+++ b/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/ignore.py
@@ -1,0 +1,28 @@
+import logging
+from stubo.ext.xmlutils import XPathValue
+from stubo.ext.xmlexit import XMLManglerExit
+
+log = logging.getLogger(__name__)
+
+element_index_func = 'count(../preceding-sibling::dateTime) + 1'
+elements = dict(year=XPathValue('//dispatchTime/dateTime/year', extractor=lambda x: x, element_index_func=element_index_func),
+                month=XPathValue('//dispatchTime/dateTime/month', element_index_func=element_index_func),
+                day=XPathValue('//dispatchTime/dateTime/day', element_index_func=element_index_func),
+                hour=XPathValue('//dispatchTime/dateTime/hour', element_index_func=element_index_func),
+                minutes=XPathValue('//dispatchTime/dateTime/minutes', element_index_func=element_index_func),
+                seconds=XPathValue('//dispatchTime/dateTime/seconds', element_index_func=element_index_func))
+
+attrs = dict(y=XPathValue('//dispatchTime/date/@year'),
+             m=XPathValue('//dispatchTime/date/@month'),
+             d=XPathValue('//dispatchTime/date/@day'))
+    
+ignore = XMLManglerExit(elements=elements, attrs=attrs)
+    
+def exits(request, context):
+    return ignore.get_exit(request, context)
+    
+
+
+        
+
+

--- a/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/ignore.py
+++ b/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/ignore.py
@@ -4,13 +4,12 @@ from stubo.ext.xmlexit import XMLManglerExit
 
 log = logging.getLogger(__name__)
 
-element_index_func = 'count(../preceding-sibling::dateTime) + 1'
-elements = dict(year=XPathValue('//dispatchTime/dateTime/year', extractor=lambda x: x, element_index_func=element_index_func),
-                month=XPathValue('//dispatchTime/dateTime/month', element_index_func=element_index_func),
-                day=XPathValue('//dispatchTime/dateTime/day', element_index_func=element_index_func),
-                hour=XPathValue('//dispatchTime/dateTime/hour', element_index_func=element_index_func),
-                minutes=XPathValue('//dispatchTime/dateTime/minutes', element_index_func=element_index_func),
-                seconds=XPathValue('//dispatchTime/dateTime/seconds', element_index_func=element_index_func))
+elements = dict(year=XPathValue('//dispatchTime/dateTime/year', extractor=lambda x: x),
+                month=XPathValue('//dispatchTime/dateTime/month'),
+                day=XPathValue('//dispatchTime/dateTime/day'),
+                hour=XPathValue('//dispatchTime/dateTime/hour'),
+                minutes=XPathValue('//dispatchTime/dateTime/minutes'),
+                seconds=XPathValue('//dispatchTime/dateTime/seconds'))
 
 attrs = dict(y=XPathValue('//dispatchTime/date/@year'),
              m=XPathValue('//dispatchTime/date/@month'),

--- a/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/matcher.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/matcher.xml
@@ -1,0 +1,23 @@
+<user:Request xmlns:user="http://www.my.com/userschema">
+<user:dispatchTime>
+        <user:businessSemantic>DTD</user:businessSemantic>
+        <user:timeMode>U</user:timeMode>
+        <user:dateTime>
+            <user:year>2014</user:year>
+            <user:month>10</user:month>
+            <user:day>01</user:day>
+            <user:hour>12</user:hour>
+            <user:minutes>24</user:minutes>
+            <user:seconds>46</user:seconds>
+        </user:dateTime>
+        <user:dateTime>
+            <user:year>2015</user:year>
+            <user:month>10</user:month>
+            <user:day>01</user:day>
+            <user:hour>12</user:hour>
+            <user:minutes>24</user:minutes>
+            <user:seconds>46</user:seconds>
+        </user:dateTime>
+        <user:date year="2014" month="10" day="01"></user:date>   
+</user:dispatchTime>
+</user:Request>

--- a/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/play.commands
+++ b/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/play.commands
@@ -1,0 +1,3 @@
+begin/session?scenario=ignore_xml&session=ignore_xml1&mode=playback
+get/response?session=ignore_xml1&tracking_level=full, request.xml
+end/session?session=ignore_xml1

--- a/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/record.commands
+++ b/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/record.commands
@@ -1,0 +1,7 @@
+put/module?name=/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/ignore.py
+delete/stubs?scenario=ignore_xml&force=true
+
+begin/session?scenario=ignore_xml&session=ignore_xml1&mode=record
+put/stub?session=ignore_xml1&ext_module=ignore&tracking_level=full, matcher.xml, response.xml
+end/session?session=ignore_xml1
+

--- a/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/request.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/request.xml
@@ -1,0 +1,23 @@
+<user:Request xmlns:user="http://www.my.com/userschema">
+<user:dispatchTime>
+        <user:businessSemantic>DTD</user:businessSemantic>
+        <user:timeMode>U</user:timeMode>
+        <user:dateTime>
+            <user:year>2014</user:year>
+            <user:month>12</user:month>
+            <user:day>25</user:day>
+            <user:hour>09</user:hour>
+            <user:minutes>30</user:minutes>
+            <user:seconds>00</user:seconds>
+        </user:dateTime>
+        <user:dateTime>
+            <user:year>2015</user:year>
+            <user:month>10</user:month>
+            <user:day>01</user:day>
+            <user:hour>12</user:hour>
+            <user:minutes>24</user:minutes>
+            <user:seconds>46</user:seconds>
+        </user:dateTime>
+        <user:date year="2014" month="12" day="25"></user:date>   
+</user:dispatchTime>
+</user:Request>

--- a/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/response.xml
+++ b/stubo/static/cmds/tests/ext/auto_mangle/skip_xml_multiple/response.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<XYZ>
+<a>goodbye</a>
+</XYZ>


### PR DESCRIPTION
This could do with a review as the solution could be improved. This implementation requires the user to provide a 'element_index_func' argument to XPathValue. I added this as I couldn't figure out a way to find the current index within the stylesheet.  

