### PR TITLE
Hotfix/skip index if not submitted

### DIFF
--- a/stubo/model/db.py
+++ b/stubo/model/db.py
@@ -112,7 +112,11 @@ class Scenario(object):
         doc['stub'] = doc['stub'].payload       
         status = self.db.scenario_stub.insert(doc)
         if 'priority' in doc['stub']:
-            self.db.scenario_stub.create_index([("stub.priority", ASCENDING), ("scenario", ASCENDING)])
+            try:
+                # creating index for priority and scenario name to optimise new stub insertion and getting lists
+                self.db.scenario_stub.create_index([("stub.priority", ASCENDING), ("scenario", ASCENDING)])
+            except Exception as ex:
+                log.debug("Failed to create index: %s" % ex)
         return 'inserted scenario_stub: {0}'.format(status)
     
     def insert_pre_stub(self, scenario, stub):

--- a/stubo/model/db.py
+++ b/stubo/model/db.py
@@ -111,7 +111,8 @@ class Scenario(object):
                     return 'updated with stateful response'
         doc['stub'] = doc['stub'].payload       
         status = self.db.scenario_stub.insert(doc)
-        self.db.scenario_stub.create_index([("stub.priority", ASCENDING), ("scenario", ASCENDING)])
+        if 'priority' in doc['stub']:
+            self.db.scenario_stub.create_index([("stub.priority", ASCENDING), ("scenario", ASCENDING)])
         return 'inserted scenario_stub: {0}'.format(status)
     
     def insert_pre_stub(self, scenario, stub):


### PR DESCRIPTION
Fixed indexing problem when no 'stub.priority' value is supplied. Usually this value is supplied, but it is not mandatory to Stub model.