### PR TITLE
Feature/tests for splitted export formats

### DIFF
--- a/stubo/model/export_commands.py
+++ b/stubo/model/export_commands.py
@@ -47,13 +47,18 @@ def export_stubs_to_commands_format(handler, scenario_name):
     scenario = Scenario()
     # get scenario pre stubs for specified scenario
     stubs = list(scenario.get_pre_stubs(scenario_name_key))
-    if len(stubs) > 0:
+    if stubs:
         for i in range(len(stubs)):
             entry = stubs[i]
             stub = Stub(entry['stub'], scenario_name_key)
-            matchers = [('{0}_{1}_{2}.textMatcher'.format(session, i, x),
-                         stub.contains_matchers()[x]) for x in range(len(
-                stub.contains_matchers()))]
+            # if stub is rest - matcher may be None, checking that
+            if stub.contains_matchers() is None:
+                cmds.append('# Stub skipped since no matchers were found. Consider using .yaml format for additional '
+                            'capabilities')
+                # skipping to next stub, this stub is not compatible with .commands format
+                continue
+            matchers = [('{0}_{1}_{2}.textMatcher'.format(session, i, x), stub.contains_matchers()[x])
+                        for x in range(len(stub.contains_matchers()))]
             matchers_str = ",".join(x[0] for x in matchers)
             url_args = stub.args()
             url_args['session'] = session

--- a/stubo/model/export_commands.py
+++ b/stubo/model/export_commands.py
@@ -127,10 +127,14 @@ def export_stubs_to_commands_format(handler, scenario_name):
                                                        request_file_name))
         cmds.append('end/session?session={0}'.format(session))
 
-    bookmarks = cache.get_all_saved_request_index_data()
-    if bookmarks:
-        cmds.append('import/bookmarks?location=bookmarks')
-        files.append(('bookmarks', json.dumps(bookmarks)))
+    try:
+        bookmarks = cache.get_all_saved_request_index_data()
+        if bookmarks:
+            cmds.append('import/bookmarks?location=bookmarks')
+            files.append(('bookmarks', json.dumps(bookmarks)))
+    except Exception as ex:
+        log.warn("failed to export bookmarks, error: %s" % ex)
+        pass
 
     files.append(('{0}.commands'.format(scenario_name),
                   b"\r\n".join(cmds)))

--- a/stubo/service/tests/test_api.py
+++ b/stubo/service/tests/test_api.py
@@ -2,207 +2,110 @@ import mock
 import unittest
 
 from stubo.testing import (
-   DummyCache, DummyScenario, DummyRequestHandler, DummyTracker, make_stub
+    DummyCache, DummyScenario, DummyRequestHandler, DummyTracker, make_stub
 )
+
 
 class Test_functions(unittest.TestCase):
 
     def test_get_dbenv(self):
         from stubo.service.api import get_dbenv
+
         request = DummyRequestHandler()
         request.settings['mongo.host'] = 'mongo'
         request.settings['mongo.port'] = 9999
         env = get_dbenv(request)
         self.assertEqual(env['host'], 'mongo')
         self.assertEqual(env['port'], 9999)
-    
+
     def test_get_dbenv_no_settings(self):
         from stubo.service.api import get_dbenv
+
         request = DummyRequestHandler()
         self.assertEqual(get_dbenv(request), None)
-        
+
+
 class TestCmds(unittest.TestCase):
-    
     def setUp(self):
-        self.patch = mock.patch('stubo.service.api.TextCommandsImporter', 
+        self.patch = mock.patch('stubo.service.api.TextCommandsImporter',
                                 DummyStuboCommandFile)
         self.patch.start()
 
     def tearDown(self):
         self.patch.stop()
-   
+
     def test_empty_cmds(self):
         from stubo.service.api import run_commands
-        response =  run_commands(DummyRequestHandler(), '')
+
+        response = run_commands(DummyRequestHandler(), '')
         self.assertEqual(response['data'], {
-            'executed_commands':  {'commands': []}, 
-            'number_of_requests': 0, 
+            'executed_commands': {'commands': []},
+            'number_of_requests': 0,
             'number_of_errors': 0})
-            
+
     def test_unsupported_cmds(self):
         from stubo.service.api import run_commands
         from stubo.exceptions import HTTPClientError
-        cmds_text = ''
+
         with self.assertRaises(HTTPClientError):
-            run_commands(DummyRequestHandler(), 'get/response')         
-            
+            run_commands(DummyRequestHandler(), 'get/response')
+
     def test_1cmd(self):
         from stubo.service.api import run_commands
-        cmds_text = 'delete/stubs?scenario=foo'    
+
+        cmds_text = 'delete/stubs?scenario=foo'
         response = run_commands(DummyRequestHandler(), cmds_text)
         self.assertEqual(response['data'], {
-            'executed_commands': {'commands': [('delete/stubs?scenario=foo', 200)]}, 
-            'number_of_requests': 1, 
+            'executed_commands': {'commands': [('delete/stubs?scenario=foo', 200)]},
+            'number_of_requests': 1,
             'number_of_errors': 0})
-        
+
     def test_1cmd_spaces(self):
         from stubo.service.api import run_commands
-        cmds_text = ' delete/stubs?scenario=foo '    
+
+        cmds_text = ' delete/stubs?scenario=foo '
         response = run_commands(DummyRequestHandler(), cmds_text)
         self.assertEqual(response['data'], {
-            'executed_commands': {'commands': [('delete/stubs?scenario=foo', 200)]}, 
-            'number_of_requests': 1, 
-            'number_of_errors': 0})    
-        
+            'executed_commands': {'commands': [('delete/stubs?scenario=foo', 200)]},
+            'number_of_requests': 1,
+            'number_of_errors': 0})
+
     def test_2cmds(self):
         from stubo.service.api import run_commands
-        cmds_text = 'delete/stubs?scenario=foo\ndelete/stubs?scenario=bar'    
+
+        cmds_text = 'delete/stubs?scenario=foo\ndelete/stubs?scenario=bar'
         response = run_commands(DummyRequestHandler(), cmds_text)
         self.assertEqual(response['data'], {
-            'executed_commands': {'commands': [('delete/stubs?scenario=foo', 200), 
-                                  ('delete/stubs?scenario=bar', 200)]}, 
+            'executed_commands': {'commands': [('delete/stubs?scenario=foo', 200),
+                                               ('delete/stubs?scenario=bar', 200)]},
             'number_of_requests': 2, 'number_of_errors': 0})
-        
+
     def test_2cmds_spaces(self):
         from stubo.service.api import run_commands
-        cmds_text = ' delete/stubs?scenario=foo\n delete/stubs?scenario=bar '    
+
+        cmds_text = ' delete/stubs?scenario=foo\n delete/stubs?scenario=bar '
         response = run_commands(DummyRequestHandler(), cmds_text)
         self.assertEqual(response['data'], {
-            'executed_commands': {'commands': [('delete/stubs?scenario=foo', 200), 
-                                  ('delete/stubs?scenario=bar', 200)]}, 
+            'executed_commands': {'commands': [('delete/stubs?scenario=foo', 200),
+                                               ('delete/stubs?scenario=bar', 200)]},
             'number_of_requests': 2, 'number_of_errors': 0})
-        
+
     def test_export_cmd(self):
         from stubo.service.api import run_commands
-        cmds_text = 'get/export?scenario=foo'    
+
+        cmds_text = 'get/export?scenario=foo'
         response = run_commands(DummyRequestHandler(), cmds_text)
         self.assertEqual(response['data'], {
-            'export_links': [('get/export?scenario=foo', [('foo.zip', 'http://localhost:8001/static/exports/localhost_foo/foo.zip'), ('foo.tar.gz', 'http://localhost:8001/static/exports/localhost_foo/foo.tar.gz'), ('foo.jar', 'http://localhost:8001/static/exports/localhost_foo/foo.jar')])], 
-            'executed_commands': {'commands': [('get/export?scenario=foo', 200)]}, 
-            'number_of_requests': 1, 
+            'export_links': [('get/export?scenario=foo',
+                              [('foo.zip', 'http://localhost:8001/static/exports/localhost_foo/foo.zip'),
+                               ('foo.tar.gz', 'http://localhost:8001/static/exports/localhost_foo/foo.tar.gz'),
+                               ('foo.jar', 'http://localhost:8001/static/exports/localhost_foo/foo.jar')])],
+            'executed_commands': {'commands': [('get/export?scenario=foo', 200)]},
+            'number_of_requests': 1,
             'number_of_errors': 0})
-                                   
-class TestSession(unittest.TestCase):    
-    
-    def setUp(self):
-        self.cache = DummyCache('localhost')
-        self.patch = mock.patch('stubo.service.api.Cache', self.cache)
-        self.patch.start()
-        self.scenario = DummyScenario()
-        self.db_patch = mock.patch('stubo.service.api.Scenario', self.scenario)
-        self.db_patch.start()
-        self.db_patch2 = mock.patch('stubo.cache.Scenario', self.scenario)
-        self.db_patch2.start()
 
-    def tearDown(self):
-        self.patch.stop() 
-        self.db_patch.stop()    
-        self.db_patch2.stop()    
-            
-    def make_request(self, **kwargs):
-        return DummyRequestHandler(**kwargs) 
-    
-    def _make_scenario(self, name, **kwargs):
-        doc = dict(name=name, **kwargs)
-        self.scenario.insert(**doc)
-    
-    def test_record_dup_scenario(self):
-        from stubo.service.api import begin_session
-        from stubo.exceptions import HTTPClientError
-        self._make_scenario('localhost:foo')
-        session_payload = { 
-            'status' : 'dormant',
-            'scenario' : 'localhost:foo',
-            'session' : '1'
-        }
-        self.cache.set_session('foo', '1', session_payload) 
-        with self.assertRaises(HTTPClientError):
-            begin_session(self.make_request(), 'foo', '1', 'record', 
-                          system_date=None, warm_cache=False)
-            
-    def test_record(self):
-        from stubo.service.api import begin_session
-        from stubo.exceptions import HTTPClientError
-        response = begin_session(self.make_request(), 'foo', '1', 'record', 
-                                 system_date=None, warm_cache=False)   
-        response['data'].pop('scenario_id')
-        self.assertEqual(response['data'], {
-            'status': 'record', 
-            'message': 'Record mode initiated....', 
-            'session': '1', 
-            'scenario': 'localhost:foo'
-        }) 
-        
-    def test_bad_mode(self):
-        from stubo.service.api import begin_session
-        from stubo.exceptions import HTTPClientError
-        self._make_scenario('localhost:foo')
-        with self.assertRaises(HTTPClientError):
-            begin_session(self.make_request(), 'foo', '1', 'xxx', 
-                          system_date=None, warm_cache=False)  
-            
-    def test_play(self):
-        from stubo.service.api import begin_session
-        from stubo.exceptions import HTTPClientError
-        self._make_scenario('localhost:foo')
-        from stubo.model.stub import Stub
-        doc = dict(scenario='localhost:foo', stub=Stub({
-            "request": {
-                "method": "POST",
-                "bodyPatterns": 
-                    { "contains": ["<status>OK</status>"] }
-                },
-            "response": {
-                "status": 200,
-                "body": "<response>YES</response>"
-            }
-        }, 'localhost:foo'))
-        
-        self.scenario.insert_stub(doc, stateful=True)
-        response = begin_session(self.make_request(), 'foo', '1', 'playback', 
-                                 system_date=None, warm_cache=False)  
-        self.assertEqual(response['data'], {
-            'status': 'playback', 
-            'message': 'Playback mode initiated....', 
-            'session': '1', 
-            'scenario': 'localhost:foo'
-        })   
-        
-    def test_play_no_scenario(self):
-        from stubo.service.api import begin_session
-        from stubo.exceptions import HTTPClientError
-        with self.assertRaises(HTTPClientError):
-            begin_session(self.make_request(), 'foo', '1', 'playback', 
-                          system_date=None, warm_cache=False) 
-            
-    def test_play_in_record_mode(self):
-        from stubo.service.api import begin_session
-        from stubo.exceptions import HTTPClientError
-        self._make_scenario('localhost:foo')
-        session_payload = { 
-            'status' : 'record',
-            'scenario' : 'localhost:foo',
-            'session' : '1'
-        }
-        self.cache.set_session('foo', '1', session_payload) 
-        with self.assertRaises(HTTPClientError):
-            begin_session(self.make_request(), 'foo', '1', 'playback', 
-                          system_date=None, warm_cache=False)           
-           
-    
 
-class TestDeleteStubs(unittest.TestCase):
-
+class TestSession(unittest.TestCase):
     def setUp(self):
         self.cache = DummyCache('localhost')
         self.patch = mock.patch('stubo.service.api.Cache', self.cache)
@@ -218,135 +121,246 @@ class TestDeleteStubs(unittest.TestCase):
         self.db_patch.stop()
         self.db_patch2.stop()
 
-    def _make_scenario(self, name,  **kwargs):
+    def make_request(self, **kwargs):
+        return DummyRequestHandler(**kwargs)
+
+    def _make_scenario(self, name, **kwargs):
         doc = dict(name=name, **kwargs)
         self.scenario.insert(**doc)
-        
+
+    def test_record_dup_scenario(self):
+        from stubo.service.api import begin_session
+        from stubo.exceptions import HTTPClientError
+
+        self._make_scenario('localhost:foo')
+        session_payload = {
+            'status': 'dormant',
+            'scenario': 'localhost:foo',
+            'session': '1'
+        }
+        self.cache.set_session('foo', '1', session_payload)
+        with self.assertRaises(HTTPClientError):
+            begin_session(self.make_request(), 'foo', '1', 'record',
+                          system_date=None, warm_cache=False)
+
+    def test_record(self):
+        from stubo.service.api import begin_session
+        response = begin_session(self.make_request(), 'foo', '1', 'record',
+                                 system_date=None, warm_cache=False)
+        response['data'].pop('scenario_id')
+        self.assertEqual(response['data'], {
+            'status': 'record',
+            'message': 'Record mode initiated....',
+            'session': '1',
+            'scenario': 'localhost:foo'
+        })
+
+    def test_bad_mode(self):
+        from stubo.service.api import begin_session
+        from stubo.exceptions import HTTPClientError
+
+        self._make_scenario('localhost:foo')
+        with self.assertRaises(HTTPClientError):
+            begin_session(self.make_request(), 'foo', '1', 'xxx',
+                          system_date=None, warm_cache=False)
+
+    def test_play(self):
+        from stubo.service.api import begin_session
+        self._make_scenario('localhost:foo')
+        from stubo.model.stub import Stub
+
+        doc = dict(scenario='localhost:foo', stub=Stub({
+            "request": {
+                "method": "POST",
+                "bodyPatterns":
+                    {"contains": ["<status>OK</status>"]}
+            },
+            "response": {
+                "status": 200,
+                "body": "<response>YES</response>"
+            }
+        }, 'localhost:foo'))
+
+        self.scenario.insert_stub(doc, stateful=True)
+        response = begin_session(self.make_request(), 'foo', '1', 'playback',
+                                 system_date=None, warm_cache=False)
+        self.assertEqual(response['data'], {
+            'status': 'playback',
+            'message': 'Playback mode initiated....',
+            'session': '1',
+            'scenario': 'localhost:foo'
+        })
+
+    def test_play_no_scenario(self):
+        from stubo.service.api import begin_session
+        from stubo.exceptions import HTTPClientError
+
+        with self.assertRaises(HTTPClientError):
+            begin_session(self.make_request(), 'foo', '1', 'playback',
+                          system_date=None, warm_cache=False)
+
+    def test_play_in_record_mode(self):
+        from stubo.service.api import begin_session
+        from stubo.exceptions import HTTPClientError
+
+        self._make_scenario('localhost:foo')
+        session_payload = {
+            'status': 'record',
+            'scenario': 'localhost:foo',
+            'session': '1'
+        }
+        self.cache.set_session('foo', '1', session_payload)
+        with self.assertRaises(HTTPClientError):
+            begin_session(self.make_request(), 'foo', '1', 'playback',
+                          system_date=None, warm_cache=False)
+
+
+class TestDeleteStubs(unittest.TestCase):
+    def setUp(self):
+        self.cache = DummyCache('localhost')
+        self.patch = mock.patch('stubo.service.api.Cache', self.cache)
+        self.patch.start()
+        self.scenario = DummyScenario()
+        self.db_patch = mock.patch('stubo.service.api.Scenario', self.scenario)
+        self.db_patch.start()
+        self.db_patch2 = mock.patch('stubo.cache.Scenario', self.scenario)
+        self.db_patch2.start()
+
+    def tearDown(self):
+        self.patch.stop()
+        self.db_patch.stop()
+        self.db_patch2.stop()
+
+    def _make_scenario(self, name, **kwargs):
+        doc = dict(name=name, **kwargs)
+        self.scenario.insert(**doc)
+
     def test_scenario_arg(self):
         from stubo.service.api import delete_stubs
-        scenario_name = 'conversation'
+
         handler = DummyRequestHandler()
         self._make_scenario('localhost:conversation')
-        response = delete_stubs(handler, scenario_name='conversation')   
-        self.assertEqual(response.get('data'), { 'scenarios': 
-            ['localhost:conversation'], 'message': 'stubs deleted.'
-        }) 
-        
+        response = delete_stubs(handler, scenario_name='conversation')
+        self.assertEqual(response.get('data'), {'scenarios': ['localhost:conversation'], 'message': 'stubs deleted.'})
+
     def test_active_sessions_playback(self):
         from stubo.service.api import delete_stubs
         from stubo.exceptions import HTTPClientError
+
         scenario_name = 'conversation'
         handler = DummyRequestHandler()
         self._make_scenario('localhost:conversation')
-        session_payload = { 
-            'status' : 'playback',
-            'scenario' : 'localhost:conversation',
-            'session' : 'joe'
+        session_payload = {
+            'status': 'playback',
+            'scenario': 'localhost:conversation',
+            'session': 'joe'
         }
-        self.cache.set_session(scenario_name, 'joe', session_payload) 
+        self.cache.set_session(scenario_name, 'joe', session_payload)
         with self.assertRaises(HTTPClientError):
             delete_stubs(handler, scenario_name=scenario_name)
-          
-            
+
     def test_active_sessions_record(self):
         from stubo.service.api import delete_stubs
         from stubo.exceptions import HTTPClientError
+
         scenario_name = 'conversation'
         handler = DummyRequestHandler()
         self._make_scenario('localhost:conversation')
-        session_payload = { 
-            'status' : 'record',
-            'scenario' : 'localhost:conversation',
-            'session' : 'joe'
+        session_payload = {
+            'status': 'record',
+            'scenario': 'localhost:conversation',
+            'session': 'joe'
         }
-        self.cache.set_session(scenario_name, 'joe', session_payload) 
+        self.cache.set_session(scenario_name, 'joe', session_payload)
         with self.assertRaises(HTTPClientError):
-            delete_stubs(handler, scenario_name=scenario_name)   
-            
+            delete_stubs(handler, scenario_name=scenario_name)
+
     def test_with_force(self):
         from stubo.service.api import delete_stubs
+
         scenario_name = 'conversation'
         handler = DummyRequestHandler()
         self._make_scenario('localhost:conversation')
-        session_payload = { 
-            'status' : 'record',
-            'scenario' : 'localhost:conversation',
-            'session' : 'joe'
+        session_payload = {
+            'status': 'record',
+            'scenario': 'localhost:conversation',
+            'session': 'joe'
         }
-        self.cache.set_session(scenario_name, 'joe', session_payload) 
-        response = delete_stubs(handler, scenario_name=scenario_name, 
-                                force=True)  
-        self.assertEqual(response.get('data'), {'scenarios': \
-            ['localhost:conversation'], 'message': 'stubs deleted.'
-        }) 
+        self.cache.set_session(scenario_name, 'joe', session_payload)
+        response = delete_stubs(handler, scenario_name=scenario_name,
+                                force=True)
+        self.assertEqual(response.get('data'), {'scenarios': ['localhost:conversation'], 'message': 'stubs deleted.'
+                                                })
         self.assertEqual(self.cache._hash.values('localhost:conversation'), {})
-        
+
     def test_delete_one_scenario(self):
         from stubo.service.api import delete_stubs
+
         handler = DummyRequestHandler()
         self._make_scenario('localhost:conversation')
         self._make_scenario('localhost:conversation2')
-        response = delete_stubs(handler, scenario_name='conversation', 
+        response = delete_stubs(handler, scenario_name='conversation',
                                 host='localhost')
-        self.assertEqual(response.get('data'), 
-         {'scenarios': ['localhost:conversation'], 'message': 'stubs deleted.'}) 
+        self.assertEqual(response.get('data'),
+                         {'scenarios': ['localhost:conversation'], 'message': 'stubs deleted.'})
         result = list(self.scenario.get_all())
         self.assertEqual(len(result), 1)
         self.assertEqual(result[0]['name'], 'localhost:conversation2')
-        
+
     def test_host_arg(self):
         from stubo.service.api import delete_stubs
+
         self._make_scenario('localhost:conversation')
         self._make_scenario('localhost:conversation2')
         response = delete_stubs(DummyRequestHandler(), host='localhost')
-        self.assertEqual(response.get('data').get('message'), 'stubs deleted.') 
-        self.assertEqual(sorted(response['data'].get('scenarios')),  
-                sorted(['localhost:conversation', 'localhost:conversation2']))
-        self.assertEqual(list(self.scenario.get_all()), []) 
-        
+        self.assertEqual(response.get('data').get('message'), 'stubs deleted.')
+        self.assertEqual(sorted(response['data'].get('scenarios')),
+                         sorted(['localhost:conversation', 'localhost:conversation2']))
+        self.assertEqual(list(self.scenario.get_all()), [])
+
     def test_host_arg2(self):
         from stubo.service.api import delete_stubs
+
         handler = DummyRequestHandler()
         self._make_scenario('localhost:conversation')
         self._make_scenario('someotherhost:conversation2')
         response = delete_stubs(handler, host='localhost')
-        self.assertEqual(response.get('data').get('message'), 'stubs deleted.') 
-        self.assertEqual(response['data'].get('scenarios'), 
-                         ['localhost:conversation']) 
+        self.assertEqual(response.get('data').get('message'), 'stubs deleted.')
+        self.assertEqual(response['data'].get('scenarios'),
+                         ['localhost:conversation'])
         result = list(self.scenario.get_all())
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['name'], 'someotherhost:conversation2')  
-        
+        self.assertEqual(result[0]['name'], 'someotherhost:conversation2')
+
     def test_host_arg3(self):
         from stubo.service.api import delete_stubs
+
         handler = DummyRequestHandler()
         self._make_scenario('localhost:conversation')
         self._make_scenario('someotherhost:conversation2')
         response = delete_stubs(handler, host='someotherhost')
-        self.assertEqual(response.get('data').get('message'), 'stubs deleted.') 
-        self.assertEqual(response['data'].get('scenarios'), 
-                         ['someotherhost:conversation2']) 
+        self.assertEqual(response.get('data').get('message'), 'stubs deleted.')
+        self.assertEqual(response['data'].get('scenarios'),
+                         ['someotherhost:conversation2'])
         result = list(self.scenario.get_all())
         self.assertEqual(len(result), 1)
-        self.assertEqual(result[0]['name'], 'localhost:conversation')  
-     
-        
+        self.assertEqual(result[0]['name'], 'localhost:conversation')
+
     def test_host_all_arg(self):
         from stubo.service.api import delete_stubs
+
         handler = DummyRequestHandler()
         self._make_scenario('localhost:conversation')
         self._make_scenario('someotherhost:conversation2')
         response = delete_stubs(handler, host='all')
-        self.assertEqual(response.get('data').get('message'), 'stubs deleted.') 
-        self.assertEqual(sorted(response['data'].get('scenarios')),  
+        self.assertEqual(response.get('data').get('message'), 'stubs deleted.')
+        self.assertEqual(sorted(response['data'].get('scenarios')),
                          sorted(['localhost:conversation',
                                  'someotherhost:conversation2']))
-        self.assertEqual(list(self.scenario.get_all()), [])        
-        
-            
-           
-class TestPutStub(unittest.TestCase):
+        self.assertEqual(list(self.scenario.get_all()), [])
 
+
+class TestPutStub(unittest.TestCase):
     def setUp(self):
         self.cache = DummyCache('localhost')
         self.patch = mock.patch('stubo.service.api.Cache', self.cache)
@@ -365,181 +379,192 @@ class TestPutStub(unittest.TestCase):
         self.db_patch.stop()
         self.db_patch2.stop()
         self.tracker_patch.stop()
-        
+
     def _make_scenario(self, name, **kwargs):
         doc = dict(name=name, **kwargs)
-        self.scenario.insert(**doc)    
-        
+        self.scenario.insert(**doc)
+
     def make_request(self, **kwargs):
-        return DummyRequestHandler(**kwargs)     
-        
+        return DummyRequestHandler(**kwargs)
+
     def test_put(self):
         from stubo.service.api import put_stub, begin_session
         from datetime import date
+
         body = {
             "request": {
                 "method": "POST",
-                "bodyPatterns": 
-                    { "contains": ["get my stub"] }
-                },
-                "response": {
-                    "status": 200,
-                    "body": "a response"
-                }
+                "bodyPatterns":
+                    {"contains": ["get my stub"]}
+            },
+            "response": {
+                "status": 200,
+                "body": "a response"
+            }
         }
         handler = DummyRequestHandler()
         handler.request.headers = {
-            'Content-Type' : 'application/json; charset=UTF-8'
+            'Content-Type': 'application/json; charset=UTF-8'
         }
         import json
+
         handler.request.body = json.dumps(body)
-        response = begin_session(self.make_request(), 'conversation', 'joe', 'record', 
-                                 system_date=None, warm_cache=False) 
-        
+        begin_session(self.make_request(), 'conversation', 'joe', 'record', system_date=None, warm_cache=False)
+
         response = put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                            priority=1) 
+                            priority=1)
         self.assertTrue('error' not in response)
         stubs = self.scenario.get_stubs('localhost:conversation')
         stubs = list(stubs)
         self.assertTrue(len(stubs) == 1)
         from stubo.model.stub import Stub
+
         stub = Stub(stubs[0]['stub'], 'localhost:conversation')
         self.assertEqual(stub.contains_matchers(), ['get my stub'])
         self.assertEqual(stub.response_body(), ['a response'])
-        self.assertEqual(stub.recorded(), str(date.today()))  
+        self.assertEqual(stub.recorded(), str(date.today()))
         self.assertEqual(stub.priority(), 1)
-     
+
     def test_put_with_module(self):
         from stubo.service.api import put_stub, begin_session
         from datetime import date
-        body = { 
+
+        body = {
             "request": {
                 "method": "POST",
-                "bodyPatterns": 
-                    { "contains": ["get my stub"] }
-                },
-                "response": {
-                    "status": 200,
-                    "body": "a response"
-                }
+                "bodyPatterns":
+                    {"contains": ["get my stub"]}
+            },
+            "response": {
+                "status": 200,
+                "body": "a response"
+            }
         }
         module = {
             u'name': u'mangler',
             u'recorded_system_date': u'2014-08-06',
             u'system_date': u'2014-08-06'
         }
-        body['module'] = module   
+        body['module'] = module
         handler = DummyRequestHandler()
         handler.request.headers = {
-            'Content-Type' : 'application/json; charset=UTF-8'
+            'Content-Type': 'application/json; charset=UTF-8'
         }
         import json
+
         handler.request.body = json.dumps(body)
-        response = begin_session(self.make_request(), 'conversation', 'joe', 'record', 
-                                 system_date=None, warm_cache=False) 
-        
+        begin_session(self.make_request(), 'conversation', 'joe', 'record', system_date=None, warm_cache=False)
+
         response = put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                            priority=2) 
+                            priority=2)
         self.assertTrue('error' not in response)
         stubs = list(self.scenario.get_stubs('localhost:conversation'))
         self.assertTrue(len(stubs) == 1)
         from stubo.model.stub import Stub
-        stub = Stub(stubs[0]['stub'], 'localhost:conversation') 
+
+        stub = Stub(stubs[0]['stub'], 'localhost:conversation')
         self.assertEqual(stub.module(), module)
         self.assertEqual(stub.contains_matchers(), ['get my stub'])
         self.assertEqual(stub.response_body(), ['a response'])
         self.assertEqual(stub.recorded(), str(date.today()))
-        self.assertEqual(stub.priority(), 2)   
-       
-             
+        self.assertEqual(stub.priority(), 2)
+
     def test_put_with_delay(self):
         from stubo.service.api import put_stub, begin_session
         from datetime import date
+
         body = {
             "request": {
                 "method": "POST",
-                "bodyPatterns": 
-                    { "contains": ["get my stub"] }
-                },
-                "response": {
-                    "status": 200,
-                    "body": "a response",
-                    "delayPolicy" : "slow"
-                }
+                "bodyPatterns":
+                    {"contains": ["get my stub"]}
+            },
+            "response": {
+                "status": 200,
+                "body": "a response",
+                "delayPolicy": "slow"
+            }
         }
         handler = DummyRequestHandler()
-        handler.request.headers = {'Content-Type' : 'application/json'}
+        handler.request.headers = {'Content-Type': 'application/json'}
         import json
+
         handler.request.body = json.dumps(body)
-        begin_session(self.make_request(), 'conversation', 'joe', 'record', 
-                      system_date=None, warm_cache=False)    
+        begin_session(self.make_request(), 'conversation', 'joe', 'record',
+                      system_date=None, warm_cache=False)
         response = put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                            priority=1) 
+                            priority=1)
         self.assertTrue('error' not in response)
         stubs = list(self.scenario.get_stubs('localhost:conversation'))
         self.assertTrue(len(stubs) == 1)
         from stubo.model.stub import Stub
-        stub = Stub(stubs[0]['stub'], 'localhost:conversation') 
-        self.assertEqual(stub.contains_matchers(), ['get my stub'])
-        self.assertEqual(stub.response_body(), ['a response'])
-        self.assertEqual(stub.recorded(), str(date.today())) 
-        self.assertEqual(stub.delay_policy(), 'slow') 
-        self.assertEqual(stub.priority(), 1)   
-        
-    def test_put_with_delay_arg_override(self):
-        from stubo.service.api import put_stub, begin_session
-        from datetime import date
-        body = {
-            "request": {
-                "method": "POST",
-                "bodyPatterns": 
-                    { "contains": ["get my stub"] }
-                },
-                "response": {
-                    "status": 200,
-                    "body": "a response",
-                    "delayPolicy" : "slow"
-                }
-        }
-        handler = DummyRequestHandler()
-        handler.request.headers = {'Content-Type' : 'application/json'}
-        import json
-        handler.request.body = json.dumps(body)
-        begin_session(self.make_request(), 'conversation', 'joe', 'record', 
-                      system_date=None, warm_cache=False)     
-        response = put_stub(handler, 'joe',  delay_policy='fast', 
-                            stateful=True, priority=1) 
-        self.assertTrue('error' not in response)
-        stubs = list(self.scenario.get_stubs('localhost:conversation'))
-        self.assertTrue(len(stubs) == 1)
-        from stubo.model.stub import Stub
+
         stub = Stub(stubs[0]['stub'], 'localhost:conversation')
         self.assertEqual(stub.contains_matchers(), ['get my stub'])
         self.assertEqual(stub.response_body(), ['a response'])
-        self.assertEqual(stub.recorded(), str(date.today())) 
-        self.assertEqual(stub.delay_policy(), 'fast') 
-        self.assertEqual(stub.priority(), 1) 
-        
-    def test_put_in_dormant(self):
-        from stubo.service.api import put_stub, begin_session, end_session
-        from stubo.exceptions import HTTPClientError
+        self.assertEqual(stub.recorded(), str(date.today()))
+        self.assertEqual(stub.delay_policy(), 'slow')
+        self.assertEqual(stub.priority(), 1)
+
+    def test_put_with_delay_arg_override(self):
+        from stubo.service.api import put_stub, begin_session
+        from datetime import date
+
         body = {
             "request": {
                 "method": "POST",
-                "bodyPatterns": 
-                    { "contains": ["get my stub"] }
-                },
-                "response": {
-                    "status": 200,
-                    "body": "a response",
-                    "delayPolicy" : "slow"
-                }
+                "bodyPatterns":
+                    {"contains": ["get my stub"]}
+            },
+            "response": {
+                "status": 200,
+                "body": "a response",
+                "delayPolicy": "slow"
+            }
         }
         handler = DummyRequestHandler()
-        handler.request.headers = {'Content-Type' : 'application/json'}
+        handler.request.headers = {'Content-Type': 'application/json'}
         import json
+
         handler.request.body = json.dumps(body)
-        begin_session(self.make_request(), 'conversation', 'joe', 'record', 
+        begin_session(self.make_request(), 'conversation', 'joe', 'record',
+                      system_date=None, warm_cache=False)
+        response = put_stub(handler, 'joe', delay_policy='fast',
+                            stateful=True, priority=1)
+        self.assertTrue('error' not in response)
+        stubs = list(self.scenario.get_stubs('localhost:conversation'))
+        self.assertTrue(len(stubs) == 1)
+        from stubo.model.stub import Stub
+
+        stub = Stub(stubs[0]['stub'], 'localhost:conversation')
+        self.assertEqual(stub.contains_matchers(), ['get my stub'])
+        self.assertEqual(stub.response_body(), ['a response'])
+        self.assertEqual(stub.recorded(), str(date.today()))
+        self.assertEqual(stub.delay_policy(), 'fast')
+        self.assertEqual(stub.priority(), 1)
+
+    def test_put_in_dormant(self):
+        from stubo.service.api import put_stub, begin_session, end_session
+        from stubo.exceptions import HTTPClientError
+
+        body = {
+            "request": {
+                "method": "POST",
+                "bodyPatterns":
+                    {"contains": ["get my stub"]}
+            },
+            "response": {
+                "status": 200,
+                "body": "a response",
+                "delayPolicy": "slow"
+            }
+        }
+        handler = DummyRequestHandler()
+        handler.request.headers = {'Content-Type': 'application/json'}
+        import json
+
+        handler.request.body = json.dumps(body)
+        begin_session(self.make_request(), 'conversation', 'joe', 'record',
                       system_date=None, warm_cache=False)
         self.tracker.insert(dict(scenario='localhost:conversation',
                                  request_text=handler.request.body,
@@ -547,75 +572,80 @@ class TestPutStub(unittest.TestCase):
                                  function='put/stub',
                                  stubo_response='<test>OK</test>'))
         end_session(self.make_request(), 'joe')
-        
-        with self.assertRaises(HTTPClientError): 
+
+        with self.assertRaises(HTTPClientError):
             put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                     priority=1)   
-            
+                     priority=1)
+
     def test_put_in_playback(self):
         from stubo.service.api import put_stub, begin_session
         from stubo.exceptions import HTTPClientError
+
         body = {
             "request": {
                 "method": "POST",
-                "bodyPatterns": 
-                    { "contains": ["get my stub"] }
-                },
-                "response": {
-                    "status": 200,
-                    "body": "a response",
-                    "delayPolicy" : "slow"
-                }
+                "bodyPatterns":
+                    {"contains": ["get my stub"]}
+            },
+            "response": {
+                "status": 200,
+                "body": "a response",
+                "delayPolicy": "slow"
+            }
         }
         handler = DummyRequestHandler()
-        handler.request.headers = {'Content-Type' : 'application/json'}
+        handler.request.headers = {'Content-Type': 'application/json'}
         import json
+
         handler.request.body = json.dumps(body)
         self._make_scenario('localhost:conversation')
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
                     'localhost:conversation')
         doc = dict(scenario='localhost:conversation', stub=stub)
         self.scenario.insert_stub(doc, stateful=True)
-        
-        begin_session(self.make_request(), 'conversation', 'joe', 'playback', 
+
+        begin_session(self.make_request(), 'conversation', 'joe', 'playback',
                       system_date=None, warm_cache=False)
-        with self.assertRaises(HTTPClientError): 
+        with self.assertRaises(HTTPClientError):
             put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                     priority=1)  
-            
+                     priority=1)
+
     def test_put_no_session(self):
         from stubo.service.api import put_stub
         from stubo.exceptions import HTTPClientError
+
         handler = DummyRequestHandler()
         from stubo.model.stub import create
-        handler.request.headers = {'Content-Type' : 'application/json'}
+
+        handler.request.headers = {'Content-Type': 'application/json'}
         import json
-        handler.request.body = json.dumps(create(request_body='x', 
+
+        handler.request.body = json.dumps(create(request_body='x',
                                                  response_body='y'))
-        with self.assertRaises(HTTPClientError): 
+        with self.assertRaises(HTTPClientError):
             put_stub(handler, 'bogus', delay_policy=None, stateful=True,
                      priority=1)
-         
-            
+
     def test_put_empty_payload(self):
         from stubo.service.api import put_stub, begin_session
         from stubo.exceptions import HTTPClientError
-        handler = DummyRequestHandler()
+
         body = {}
         handler = DummyRequestHandler()
-        handler.request.headers = {'Content-Type' : 'application/json'}
+        handler.request.headers = {'Content-Type': 'application/json'}
         import json
-        handler.request.body = json.dumps(body)
-        begin_session(self.make_request(), 'conversation', 'joe', 'record', 
-                      system_date=None, warm_cache=False)
-        with self.assertRaises(HTTPClientError): 
-            put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                     priority=1) 
-                                  
-                                 
-class TestPutStubLegacy(unittest.TestCase):
 
+        handler.request.body = json.dumps(body)
+        begin_session(self.make_request(), 'conversation', 'joe', 'record',
+                      system_date=None, warm_cache=False)
+        with self.assertRaises(HTTPClientError):
+            put_stub(handler, 'joe', delay_policy=None, stateful=True,
+                     priority=1)
+
+
+class TestPutStubLegacy(unittest.TestCase):
     def setUp(self):
         self.cache = DummyCache('localhost')
         self.patch = mock.patch('stubo.service.api.Cache', self.cache)
@@ -633,99 +663,104 @@ class TestPutStubLegacy(unittest.TestCase):
 
     def _make_scenario(self, name, **kwargs):
         doc = dict(name=name, **kwargs)
-        self.scenario.insert(**doc)    
-        
+        self.scenario.insert(**doc)
+
     def make_request(self, **kwargs):
-        return DummyRequestHandler(**kwargs) 
+        return DummyRequestHandler(**kwargs)
 
     def test_put(self):
         from stubo.service.api import put_stub, begin_session
         from datetime import date
+
         body = '||textMatcher||get my stub||response||a response'
         handler = DummyRequestHandler()
         handler.request.body = body
-        begin_session(self.make_request(), 'conversation', 'joe', 'record', 
+        begin_session(self.make_request(), 'conversation', 'joe', 'record',
                       system_date=None, warm_cache=False)
         response = put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                            priority=1) 
+                            priority=1)
         self.assertTrue('error' not in response)
         stubs = list(self.scenario.get_stubs('localhost:conversation'))
         self.assertTrue(len(stubs) == 1)
         from stubo.model.stub import Stub
+
         stub = Stub(stubs[0]['stub'], 'localhost:conversation')
         self.assertEqual(stub.contains_matchers(), ['get my stub'])
         self.assertEqual(stub.response_body(), ['a response'])
         self.assertEqual(stub.recorded(), str(date.today()))
         self.assertEqual(stub.priority(), 1)
-        
+
     def test_put_with_delay(self):
         from stubo.service.api import put_stub, begin_session
         from datetime import date
+
         handler = DummyRequestHandler()
         handler.request.body = '||textMatcher||get my stub||response||a response'
-        begin_session(self.make_request(), 'conversation', 'joe', 'record', 
-                      system_date=None, warm_cache=False) 
-        response = put_stub(handler, 'joe', delay_policy='slow', stateful=True,
-                            priority=1) 
+        begin_session(self.make_request(), 'conversation', 'joe', 'record',
+                      system_date=None, warm_cache=False)
+        put_stub(handler, 'joe', delay_policy='slow', stateful=True, priority=1)
         stubs = list(self.scenario.get_stubs('localhost:conversation'))
         self.assertTrue(len(stubs) == 1)
         from stubo.model.stub import Stub
+
         stub = Stub(stubs[0]['stub'], 'localhost:conversation')
         self.assertEqual(stub.contains_matchers(), ['get my stub'])
         self.assertEqual(stub.response_body(), ['a response'])
         self.assertEqual(stub.recorded(), str(date.today()))
-        self.assertEqual(stub.delay_policy(), 'slow') 
+        self.assertEqual(stub.delay_policy(), 'slow')
         self.assertEqual(stub.priority(), 1)
-    
+
     def test_put_no_session(self):
         from stubo.service.api import put_stub
         from stubo.exceptions import HTTPClientError
+
         handler = DummyRequestHandler()
         handler.request.body = '||textMatcher||get my stub||response||a response'
-        with self.assertRaises(HTTPClientError): 
+        with self.assertRaises(HTTPClientError):
             put_stub(handler, 'bogus', delay_policy=None, stateful=True,
                      priority=1)
-         
-            
+
     def test_put_no_text_in_body(self):
         from stubo.service.api import put_stub, begin_session
         from stubo.exceptions import HTTPClientError
+
         body = ''
         handler = DummyRequestHandler()
         handler.request.body = body
-        begin_session(self.make_request(), 'conversation', 'joe', 'record', 
-                      system_date=None, warm_cache=False) 
-        with self.assertRaises(HTTPClientError): 
+        begin_session(self.make_request(), 'conversation', 'joe', 'record',
+                      system_date=None, warm_cache=False)
+        with self.assertRaises(HTTPClientError):
             put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                     priority=1) 
-            
+                     priority=1)
+
     def test_put_bad_text_in_body(self):
         from stubo.service.api import put_stub, begin_session
         from stubo.exceptions import HTTPClientError
+
         body = 'textMatcher||get my stub||response||a response'
         handler = DummyRequestHandler()
         handler.request.body = body
-        begin_session(self.make_request(), 'conversation', 'joe', 'record', 
-                      system_date=None, warm_cache=False)  
-        with self.assertRaises(HTTPClientError): 
+        begin_session(self.make_request(), 'conversation', 'joe', 'record',
+                      system_date=None, warm_cache=False)
+        with self.assertRaises(HTTPClientError):
             put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                     priority=1) 
-            
+                     priority=1)
+
     def test_put_bad_text_in_body2(self):
         from stubo.service.api import put_stub, begin_session
         from stubo.exceptions import HTTPClientError
+
         body = '||textMatcher||get my stub||a response'
         handler = DummyRequestHandler()
         handler.request.body = body
-        begin_session(self.make_request(), 'conversation', 'joe', 'record', 
-                      system_date=None, warm_cache=False) 
-        with self.assertRaises(HTTPClientError): 
+        begin_session(self.make_request(), 'conversation', 'joe', 'record',
+                      system_date=None, warm_cache=False)
+        with self.assertRaises(HTTPClientError):
             put_stub(handler, 'joe', delay_policy=None, stateful=True,
-                     priority=1) 
-              
-        
-class TestStubCount(unittest.TestCase):
+                     priority=1)
 
+
+class TestStubCount(unittest.TestCase):
     def setUp(self):
         self.scenario = DummyScenario()
         self.db_patch = mock.patch('stubo.service.api.Scenario', self.scenario)
@@ -733,44 +768,46 @@ class TestStubCount(unittest.TestCase):
 
     def tearDown(self):
         self.db_patch.stop()
-        
+
     def _make_scenario(self, name, **kwargs):
         doc = dict(name=name, **kwargs)
-        self.scenario.insert(**doc)        
-
+        self.scenario.insert(**doc)
 
     def test_2stubs(self):
         from stubo.service.api import stub_count
+
         self._make_scenario('localhost:2stub1matcher')
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
                     'localhost:2stub1matcher')
         doc = dict(scenario='localhost:2stub1matcher', stub=stub)
         self.scenario.insert_stub(doc, stateful=True)
-        
+
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this 2</test>', '<test>OK</test>'),
                     'localhost:2stub1matcher')
         doc = dict(scenario='localhost:2stub1matcher', stub=stub)
         self.scenario.insert_stub(doc, stateful=True)
-        
+
         response = stub_count('localhost', '2stub1matcher')
         self.assertEqual(response['data']['count'], 2)
 
-    def test_no_scenario(self): 
+    def test_no_scenario(self):
         from stubo.service.api import stub_count
+
         response = stub_count('localhost', 'bogus')
         self.assertEqual(response['data']['count'], 0)
-        
+
     """ FIXME
     def test_regex_scenario(self): 
         from stubo.service.api import stub_count
         response = stub_count('localhost')
         self.assertEqual(response['data']['count'], 0)"""
-        
+
 
 class TestStubList(unittest.TestCase):
-    
     def setUp(self):
         self.scenario = DummyScenario()
         self.db_patch = mock.patch('stubo.service.api.Scenario', self.scenario)
@@ -778,15 +815,17 @@ class TestStubList(unittest.TestCase):
 
     def tearDown(self):
         self.db_patch.stop()
-        
+
     def _make_scenario(self, name, **kwargs):
         doc = dict(name=name, **kwargs)
-        self.scenario.insert(**doc)    
-        
+        self.scenario.insert(**doc)
+
     def test_1stub_1matcher(self):
-        from stubo.service.api import list_stubs  
+        from stubo.service.api import list_stubs
+
         self._make_scenario('localhost:1stub1matcher')
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
                     'localhost:1stub1matcher')
         doc = dict(scenario='localhost:1stub1matcher', stub=stub)
@@ -796,40 +835,43 @@ class TestStubList(unittest.TestCase):
         stubs = response['data']['stubs']
         self.assertTrue(len(stubs) == 1)
         from stubo.model.stub import Stub
+
         stub = Stub(stubs[0], 'localhost:1stub1matcher')
         self.assertEqual(stub.contains_matchers(), ['<test>match this</test>'])
         self.assertEqual(stub.response_body(), ['<test>OK</test>'])
-        
-   
+
     def test_2stub_1matcher(self):
-        from stubo.service.api import list_stubs  
+        from stubo.service.api import list_stubs
+
         self._make_scenario('localhost:2stub1matcher')
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
                     'localhost:2stub1matcher')
         doc = dict(scenario='localhost:2stub1matcher', stub=stub)
         self.scenario.insert_stub(doc, stateful=True)
-        
+
         from stubo.model.stub import create, Stub
+
         stub2 = Stub(create('<test>match this 2</test>', '<test>OK</test>'),
-                    'localhost:2stub1matcher')
+                     'localhost:2stub1matcher')
         doc2 = dict(scenario='localhost:2stub1matcher', stub=stub2)
         self.scenario.insert_stub(doc2, stateful=True)
-        
+
         response = list_stubs(DummyRequestHandler(), '2stub1matcher')
         self.assertTrue('stubs' in response.get('data'))
         stubs = response['data']['stubs']
         self.assertTrue(len(stubs) == 2)
-      
+
         # ming insert not in doc order all the time?
-        #from stubo.model.stub import Stub
-        #stub = Stub(stubs[0], 'localhost:2stub1matcher')
-        #self.assertEqual(stub.contains_matchers(), ['<test>match this</test>'])
-        #stub2 = Stub(stubs[1], 'localhost:2stub1matcher')
-        #self.assertEqual(stub2.contains_matchers(), ['<test>match this 2</test>'])
-        
+        # from stubo.model.stub import Stub
+        # stub = Stub(stubs[0], 'localhost:2stub1matcher')
+        # self.assertEqual(stub.contains_matchers(), ['<test>match this</test>'])
+        # stub2 = Stub(stubs[1], 'localhost:2stub1matcher')
+        # self.assertEqual(stub2.contains_matchers(), ['<test>match this 2</test>'])
+
+
 class TestGetStubs(unittest.TestCase):
-    
     def setUp(self):
         self.scenario = DummyScenario()
         self.db_patch = mock.patch('stubo.service.api.Scenario', self.scenario)
@@ -837,51 +879,55 @@ class TestGetStubs(unittest.TestCase):
 
     def tearDown(self):
         self.db_patch.stop()
-        
+
     def _make_scenario(self, name, **kwargs):
         doc = dict(name=name, **kwargs)
-        self.scenario.insert(**doc)    
-        
+        self.scenario.insert(**doc)
+
     def test_get_stubs(self):
-        from stubo.service.api import get_stubs  
+        from stubo.service.api import get_stubs
+
         self._make_scenario('localhost:1stub1matcher')
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
                     'localhost:1stub1matcher')
         doc = dict(scenario='localhost:1stub1matcher', stub=stub)
-        self.scenario.insert_stub(doc, stateful=True)  
+        self.scenario.insert_stub(doc, stateful=True)
         response = get_stubs('localhost', '1stub1matcher')
         response = list(response)
         self.assertEqual(len(response), 1)
         response = response[0]
         response.pop('_id')
-        self.assertEqual(response, dict(stub=
-          {u'request': {u'bodyPatterns': {u'contains': [u'<test>match this</test>']},
-                         u'method': u'POST'},
-           u'response': {u'body': u'<test>OK</test>', u'status': 200}}, scenario='localhost:1stub1matcher')) 
-      
+        self.assertEqual(response,
+                         dict(stub={u'request': {u'bodyPatterns': {u'contains': [u'<test>match this</test>']},
+                                                 u'method': u'POST'},
+                                    u'response': {u'body': u'<test>OK</test>', u'status': 200}},
+                              scenario='localhost:1stub1matcher'))
+
     def test_get_stubs_host_arg(self):
-        from stubo.service.api import get_stubs  
+        from stubo.service.api import get_stubs
+
         self._make_scenario('localhost:1stub1matcher')
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
                     'localhost:1stub1matcher')
         doc = dict(scenario='localhost:1stub1matcher', stub=stub)
-        self.scenario.insert_stub(doc, stateful=True)  
+        self.scenario.insert_stub(doc, stateful=True)
         response = get_stubs('localhost')
         response = list(response)
         self.assertEqual(len(response), 1)
         response = response[0]
         response.pop('_id')
-        self.assertEqual(response, dict(stub=
-          {u'request': {u'bodyPatterns': {u'contains': [u'<test>match this</test>']},
-                         u'method': u'POST'},
-           u'response': {u'body': u'<test>OK</test>', u'status': 200}}, 
-                                        scenario='localhost:1stub1matcher')) 
-            
-           
-class TestStubExport(unittest.TestCase):
+        self.assertEqual(response,
+                         dict(stub={u'request': {u'bodyPatterns': {u'contains': [u'<test>match this</test>']},
+                                                 u'method': u'POST'},
+                                    u'response': {u'body': u'<test>OK</test>', u'status': 200}},
+                              scenario='localhost:1stub1matcher'))
 
+
+class TestStubExport(unittest.TestCase):
     def setUp(self):
         self.cache = DummyCache('localhost')
         self.patch = mock.patch('stubo.service.api.Cache', self.cache)
@@ -898,7 +944,7 @@ class TestStubExport(unittest.TestCase):
         self.tracker_patch0.start()
         self.tracker_patch = mock.patch('stubo.model.exporter.Tracker', self.tracker)
         self.tracker_patch.start()
-    
+
     def tearDown(self):
         self.patch.stop()
         self.db_patch.stop()
@@ -906,61 +952,65 @@ class TestStubExport(unittest.TestCase):
         self.db_patch2.stop()
         self.tracker_patch0.stop()
         self.tracker_patch.stop()
-    
+
     def _make_scenario(self, name, **kwargs):
         doc = dict(name=name, **kwargs)
-        self.scenario.insert(**doc)    
-                  
+        self.scenario.insert(**doc)
+
     def _delete_tmp_export_dir(self, scenario_dir):
-        import shutil    
+        import shutil
+
         shutil.rmtree(scenario_dir)
-        
+
     def test_runnable_requires_playback_session(self):
         from stubo.service.api import export_stubs
-        import os.path
         from stubo.exceptions import HTTPClientError
+
         request_handler = DummyRequestHandler(session_id=['1'], runnable=['true'])
         self._make_scenario('localhost:1stub1matcher')
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
                     'localhost:1stub1matcher')
         doc = dict(scenario='localhost:1stub1matcher', stub=stub)
-        self.scenario.insert_stub(doc, stateful=True) 
-        self.scenario.insert_pre_stub('localhost:1stub1matcher', stub) 
-        with self.assertRaises(HTTPClientError): 
-            export_stubs(request_handler, '1stub1matcher')   
-            
-    def test_runnable_requires_playback(self):
-        from stubo.service.api import export_stubs
-        import os.path
-        from stubo.exceptions import HTTPClientError
-        request_handler = DummyRequestHandler(session_id=['1'], 
-                                              runnable=['true'],
-                                              playback_session=['myrunnable'])
-        self._make_scenario('localhost:1stub1matcher')
-        from stubo.model.stub import create, Stub
-        stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
-                    'localhost:1stub1matcher')
-        doc = dict(scenario='localhost:1stub1matcher', stub=stub)
-        self.scenario.insert_stub(doc, stateful=True) 
+        self.scenario.insert_stub(doc, stateful=True)
         self.scenario.insert_pre_stub('localhost:1stub1matcher', stub)
         with self.assertRaises(HTTPClientError):
             export_stubs(request_handler, '1stub1matcher')
-    
-    def test_runnable(self):
+
+    def test_runnable_requires_playback(self):
         from stubo.service.api import export_stubs
-        import os.path
         from stubo.exceptions import HTTPClientError
-        request_handler = DummyRequestHandler(session_id=['1'], 
+
+        request_handler = DummyRequestHandler(session_id=['1'],
                                               runnable=['true'],
                                               playback_session=['myrunnable'])
         self._make_scenario('localhost:1stub1matcher')
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
                     'localhost:1stub1matcher')
         doc = dict(scenario='localhost:1stub1matcher', stub=stub)
-        self.scenario.insert_stub(doc, stateful=True) 
+        self.scenario.insert_stub(doc, stateful=True)
+        self.scenario.insert_pre_stub('localhost:1stub1matcher', stub)
+        with self.assertRaises(HTTPClientError):
+            export_stubs(request_handler, '1stub1matcher')
+
+    def test_runnable(self):
+        from stubo.service.api import export_stubs
+
+        request_handler = DummyRequestHandler(session_id=['1'],
+                                              runnable=['true'],
+                                              playback_session=['myrunnable'])
+        self._make_scenario('localhost:1stub1matcher')
+        from stubo.model.stub import create, Stub
+
+        stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
+                    'localhost:1stub1matcher')
+        doc = dict(scenario='localhost:1stub1matcher', stub=stub)
+        self.scenario.insert_stub(doc, stateful=True)
         import json
+
         payload = json.dumps(stub.payload)
         self.tracker.insert(dict(scenario='localhost:1stub1matcher',
                                  request_text=payload,
@@ -968,53 +1018,55 @@ class TestStubExport(unittest.TestCase):
                                  request_headers=dict(),
                                  function='put/stub',
                                  stubo_response='<test>OK</test>'))
-        response =  export_stubs(request_handler, '1stub1matcher') 
+        response = export_stubs(request_handler, '1stub1matcher')
         self.assertTrue('runnable' in response['data'])
         runnable = response['data']['runnable']
-        self.assertEqual(runnable.get('playback_session'),  'myrunnable')
+        self.assertEqual(runnable.get('playback_session'), 'myrunnable')
         self.assertEqual(runnable.get('number_of_playback_requests'), 1)
-                         
+
     def test_1stub_1matcher(self):
         from stubo.service.api import export_stubs
         import os.path
+
         request_handler = DummyRequestHandler(session_id=['1'])
         self._make_scenario('localhost:1stub1matcher')
         from stubo.model.stub import create, Stub
+
         stub = Stub(create('<test>match this</test>', '<test>OK</test>'),
                     'localhost:1stub1matcher')
-        self.scenario.insert_pre_stub('localhost:1stub1matcher', stub) 
-        
+        self.scenario.insert_pre_stub('localhost:1stub1matcher', stub)
+
         response = export_stubs(request_handler, '1stub1matcher').get('data')
         self.assertEqual(response['scenario'], '1stub1matcher')
         self.assertTrue(len(response['yaml_links']), 5)
-        local_server = 'http://{0}:{1}'.format(request_handler.track.server, 
-                                           request_handler.track.port) 
+        local_server = 'http://{0}:{1}'.format(request_handler.track.server,
+                                               request_handler.track.port)
         self.assertEqual(response['yaml_links'], [
-        ('1stub1matcher_1_0.json',
-         local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher_1_0.json'),
-        ('1stub1matcher.yaml',
-         local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher.yaml'),
-        ('1stub1matcher.zip',
-         local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher.zip'),
-        ('1stub1matcher.tar.gz',
-         local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher.tar.gz'),
-        ('1stub1matcher.jar',
-         local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher.jar')])
+            ('1stub1matcher_1_0.json',
+             local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher_1_0.json'),
+            ('1stub1matcher.yaml',
+             local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher.yaml'),
+            ('1stub1matcher.zip',
+             local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher.zip'),
+            ('1stub1matcher.tar.gz',
+             local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher.tar.gz'),
+            ('1stub1matcher.jar',
+             local_server + '/static/exports/localhost_1stub1matcher/yaml_format/1stub1matcher.jar')])
 
-        scenario_dir = response['export_dir_path'] 
+        scenario_dir = response['export_dir_path']
         files = [os.path.join(scenario_dir, x[0]) for x in response['yaml_links']]
         for f in files:
             self.assertTrue(os.path.exists(f))
-        
+
         expected = ['recording:\n', '  scenario: 1stub1matcher\n',
                     "  session: '{{session}}'\n", '  stubs:\n', '  - file: 1stub1matcher_1_0.json\n']
 
-        with open(os.path.join(scenario_dir, '1stub1matcher.yaml')) as f: 
+        with open(os.path.join(scenario_dir, '1stub1matcher.yaml')) as f:
             lines = f.readlines()
-            self.assertEqual([x.strip() for x in lines[2:]], 
-                             [x.strip() for x in expected]) 
-            
-        with open(os.path.join(scenario_dir, '1stub1matcher_1_0.json')) as f: 
+            self.assertEqual([x.strip() for x in lines[2:]],
+                             [x.strip() for x in expected])
+
+        with open(os.path.join(scenario_dir, '1stub1matcher_1_0.json')) as f:
             payload = f.read()
             self.assertEqual(payload, """{
    "args": {}, 
@@ -1030,79 +1082,84 @@ class TestStubExport(unittest.TestCase):
       "body": "<test>OK</test>", 
       "status": 200
    }
-}""")       
+}""")
         self._delete_tmp_export_dir(scenario_dir)
-                    
+
     def test_1stub_2matcher(self):
         from stubo.service.api import export_stubs
         import os.path
+
         scenario_name = 'x'
         handler = DummyRequestHandler(session_id=['1'])
         self._make_scenario('localhost:x')
-        from stubo.model.stub import create, Stub
+        from stubo.model.stub import Stub
+
         stub = Stub(make_stub(['<test>match this</test>',
                                '<test>and this</test>'], '<test>OK</test>',
                               delay_policy='slow'), scenario=scenario_name)
-        self.scenario.insert_pre_stub('localhost:x', stub)  
+        self.scenario.insert_pre_stub('localhost:x', stub)
         response = export_stubs(handler, scenario_name).get('data')
         self.assertEqual(response['scenario'], scenario_name)
         self.assertTrue(len(response['yaml_links']), 6)
-        local_server = 'http://{0}:{1}'.format(handler.track.server, 
-                                           handler.track.port) 
+        local_server = 'http://{0}:{1}'.format(handler.track.server,
+                                               handler.track.port)
         self.assertEqual(response['yaml_links'], [
-        ('x_1_0.json', local_server + '/static/exports/localhost_x/yaml_format/x_1_0.json'),
-        ('x.yaml', local_server + '/static/exports/localhost_x/yaml_format/x.yaml'),
-        ('x.zip', local_server + '/static/exports/localhost_x/yaml_format/x.zip'),
-        ('x.tar.gz', local_server + '/static/exports/localhost_x/yaml_format/x.tar.gz'),
-        ('x.jar', local_server + '/static/exports/localhost_x/yaml_format/x.jar')])
-        
-        scenario_dir = response['export_dir_path'] 
+            ('x_1_0.json', local_server + '/static/exports/localhost_x/yaml_format/x_1_0.json'),
+            ('x.yaml', local_server + '/static/exports/localhost_x/yaml_format/x.yaml'),
+            ('x.zip', local_server + '/static/exports/localhost_x/yaml_format/x.zip'),
+            ('x.tar.gz', local_server + '/static/exports/localhost_x/yaml_format/x.tar.gz'),
+            ('x.jar', local_server + '/static/exports/localhost_x/yaml_format/x.jar')])
+
+        scenario_dir = response['export_dir_path']
         files = [os.path.join(scenario_dir, x[0]) for x in response['yaml_links']]
         for f in files:
             self.assertTrue(os.path.exists(f))
-        
+
         self._delete_tmp_export_dir(scenario_dir)
-        
+
     def test_2stub_2matcher(self):
         from stubo.service.api import export_stubs
         import os.path
+
         scenario_name = 'x'
         self._make_scenario('localhost:x')
-        from stubo.model.stub import create, Stub
+        from stubo.model.stub import Stub
+
         stub = Stub(make_stub(['<test>match this</test>',
                                '<test>and this</test>'], '<test>OK</test>',
                               delay_policy='slow'), scenario=scenario_name)
-        self.scenario.insert_pre_stub('localhost:x', stub) 
-        
+        self.scenario.insert_pre_stub('localhost:x', stub)
+
         stub2 = Stub(make_stub(['<test>match this 2</test>',
-                               '<test>and this</test>'], '<test>OK</test>',
-                              delay_policy='slow'), scenario=scenario_name)
-        self.scenario.insert_pre_stub('localhost:x', stub2) 
-        
+                                '<test>and this</test>'], '<test>OK</test>',
+                               delay_policy='slow'), scenario=scenario_name)
+        self.scenario.insert_pre_stub('localhost:x', stub2)
+
         handler = DummyRequestHandler(session_id=['1'])
-        response = export_stubs(handler, scenario_name).get('data')     
+        response = export_stubs(handler, scenario_name).get('data')
         self.assertEqual(response['scenario'], scenario_name)
         self.assertTrue(len(response['yaml_links']), 9)
-        local_server = 'http://{0}:{1}'.format(handler.track.server, 
-                                           handler.track.port) 
+        local_server = 'http://{0}:{1}'.format(handler.track.server,
+                                               handler.track.port)
         self.assertEqual(response['yaml_links'], [
-        ('x_1_0.json', local_server + '/static/exports/localhost_x/yaml_format/x_1_0.json'),
-        ('x_1_1.json', local_server + '/static/exports/localhost_x/yaml_format/x_1_1.json'),
-        ('x.yaml', local_server + '/static/exports/localhost_x/yaml_format/x.yaml'),
-        ('x.zip', local_server + '/static/exports/localhost_x/yaml_format/x.zip'),
-        ('x.tar.gz', local_server + '/static/exports/localhost_x/yaml_format/x.tar.gz'),
-        ('x.jar', local_server + '/static/exports/localhost_x/yaml_format/x.jar')])
+            ('x_1_0.json', local_server + '/static/exports/localhost_x/yaml_format/x_1_0.json'),
+            ('x_1_1.json', local_server + '/static/exports/localhost_x/yaml_format/x_1_1.json'),
+            ('x.yaml', local_server + '/static/exports/localhost_x/yaml_format/x.yaml'),
+            ('x.zip', local_server + '/static/exports/localhost_x/yaml_format/x.zip'),
+            ('x.tar.gz', local_server + '/static/exports/localhost_x/yaml_format/x.tar.gz'),
+            ('x.jar', local_server + '/static/exports/localhost_x/yaml_format/x.jar')])
 
-        scenario_dir = response['export_dir_path'] 
+        scenario_dir = response['export_dir_path']
         files = [os.path.join(scenario_dir, x[0]) for x in response['yaml_links']]
         for f in files:
-            self.assertTrue(os.path.exists(f)) 
-        
+            self.assertTrue(os.path.exists(f))
+
         self._delete_tmp_export_dir(scenario_dir)
 
     def test_0stub_0matcher(self):
         from stubo.service.api import export_stubs
         import os.path
+
         request_handler = DummyRequestHandler(session_id=['1'])
         self._make_scenario('localhost:0stub0matcher')
 
@@ -1110,136 +1167,138 @@ class TestStubExport(unittest.TestCase):
         self.assertEqual(response['scenario'], '0stub0matcher')
         self.assertTrue(len(response['yaml_links']), 5)
         self.assertTrue(len(response['command_links']), 4)
-        local_server = 'http://{0}:{1}'.format(request_handler.track.server, 
-                                           request_handler.track.port)
+        local_server = 'http://{0}:{1}'.format(request_handler.track.server,
+                                               request_handler.track.port)
 
         self.assertEqual(response['yaml_links'], [
-          ('0stub0matcher_1_0.json',
-           local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher_1_0.json'),
-          ('0stub0matcher.yaml',
-           local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher.yaml'),
-          ('0stub0matcher.zip',
-           local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher.zip'),
-          ('0stub0matcher.tar.gz',
-           local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher.tar.gz'),
-          ('0stub0matcher.jar',
-           local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher.jar')
-          ])
+            ('0stub0matcher_1_0.json',
+             local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher_1_0.json'),
+            ('0stub0matcher.yaml',
+             local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher.yaml'),
+            ('0stub0matcher.zip',
+             local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher.zip'),
+            ('0stub0matcher.tar.gz',
+             local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher.tar.gz'),
+            ('0stub0matcher.jar',
+             local_server + '/static/exports/localhost_0stub0matcher/yaml_format/0stub0matcher.jar')
+        ])
         scenario_dir = response['export_dir_path']
         files = [os.path.join(scenario_dir, x[0]) for x in response['yaml_links']]
         for f in files:
             self.assertTrue(os.path.exists(f))
-       
+
         expected = ['recording:\n', '  scenario: 0stub0matcher\n', "  session: '{{session}}'\n", '  stubs: []\n']
-        cmds = [
-            'delete/stubs?scenario=0stub0matcher',
-            'begin/session?scenario=0stub0matcher&session={{session}}&mode=record',
-            'put/stub?session={{session}},text=a_dummy_matcher,text=a_dummy_response',
-            'end/session?session={{session}}',
-        ]  
-        
+
         with open(os.path.join(scenario_dir, '0stub0matcher.yaml')) as f:
-            lines = f.readlines() 
-            self.assertEqual([x.strip() for x in lines[2:]], 
-                             [x.strip() for x in expected]) 
-            
+            lines = f.readlines()
+            self.assertEqual([x.strip() for x in lines[2:]],
+                             [x.strip() for x in expected])
+
         self._delete_tmp_export_dir(scenario_dir)
-                
+
+
 class TestDelayPolicy(unittest.TestCase):
-    
     def setUp(self):
         self.cache = DummyCache('localhost')
         self.patch = mock.patch('stubo.service.api.Cache', self.cache)
         self.patch.start()
 
     def tearDown(self):
-        self.patch.stop()   
-            
+        self.patch.stop()
+
     def make_request(self, **kwargs):
-        return DummyRequestHandler(**kwargs) 
-    
+        return DummyRequestHandler(**kwargs)
+
     def test_get_empty(self):
         from stubo.service.api import get_delay_policy
+
         response = get_delay_policy(self.make_request(), 'bogus', True)
         self.assertEqual(response['data'], {})
-        
+
     def test_get(self):
         from stubo.service.api import get_delay_policy
+
         self.cache.set_delay_policy('slow', {u'delay_type': u'fixed', u'name': u'slow', u'milliseconds': u'200'})
         response = get_delay_policy(self.make_request(), 'slow', True)
         self.assertEqual(response['data'], {u'delay_type': u'fixed', u'name': u'slow', u'milliseconds': u'200'})
-        
+
     def test_delete(self):
         from stubo.service.api import delete_delay_policy
-        self.cache.set_delay_policy('slow', {u'delay_type': u'fixed', 
-            u'name': u'slow', u'milliseconds': u'200'})
+
+        self.cache.set_delay_policy('slow', {u'delay_type': u'fixed',
+                                             u'name': u'slow', u'milliseconds': u'200'})
         response = delete_delay_policy(self.make_request(), ['slow'])
         response2 = self.cache.get_delay_policy('slow')
-        self.assertEqual(self.cache.get_delay_policy(self.make_request(), 
+        self.assertEqual(self.cache.get_delay_policy(self.make_request(),
                                                      'slow'), None)
         self.assertEqual(response['data'].get('message'),
                          "Deleted 1 delay policies from ['slow']")
-        
+
     def test_multi_delete(self):
         from stubo.service.api import delete_delay_policy
-        self.cache.set_delay_policy('slow', {u'delay_type': u'fixed', 
-            u'name': u'slow', u'milliseconds': u'200'})
-        self.cache.set_delay_policy('fast', {u'delay_type': u'fixed', 
-            u'name': u'slow', u'milliseconds': u'1'})
-        
+
+        self.cache.set_delay_policy('slow', {u'delay_type': u'fixed',
+                                             u'name': u'slow', u'milliseconds': u'200'})
+        self.cache.set_delay_policy('fast', {u'delay_type': u'fixed',
+                                             u'name': u'slow', u'milliseconds': u'1'})
+
         response = delete_delay_policy(self.make_request(), ['slow', 'fast'])
         self.assertEqual(response['data'].get('message'),
-                          "Deleted 2 delay policies from ['slow', 'fast']")    
-            
+                         "Deleted 2 delay policies from ['slow', 'fast']")
+
     def test_put_fixed(self):
         from stubo.service.api import update_delay_policy
+
         args = {
-          'delay_type' : 'fixed',
-          'name' : 'x',
-          'milliseconds' : '700'
+            'delay_type': 'fixed',
+            'name': 'x',
+            'milliseconds': '700'
         }
         response = update_delay_policy(self.make_request(), args)
         self.assertEqual(response['data']['message'],
-            "Put Delay Policy Finished")
+                         "Put Delay Policy Finished")
         self.assertEqual(self.cache.get_delay_policy('x'),
-            {'delay_type': 'fixed', 'name': 'x', 'milliseconds': '700'})
-        
+                         {'delay_type': 'fixed', 'name': 'x', 'milliseconds': '700'})
+
     def test_put_normalvariate(self):
         from stubo.service.api import update_delay_policy
+
         args = {
-          'delay_type' : 'normalvariate',
-          'name' : 'x',
-          'mean' : '100',
-          'stddev' : '50'
+            'delay_type': 'normalvariate',
+            'name': 'x',
+            'mean': '100',
+            'stddev': '50'
         }
         response = update_delay_policy(self.make_request(), args)
         self.assertEqual(response['data']['message'],
-            "Put Delay Policy Finished")
-        self.assertEqual(self.cache.get_delay_policy('x'), 
+                         "Put Delay Policy Finished")
+        self.assertEqual(self.cache.get_delay_policy('x'),
                          {'delay_type': 'normalvariate', 'name': 'x',
-                          'mean': '100', 'stddev' : '50'})
-        
+                          'mean': '100', 'stddev': '50'})
+
     def test_put_weighted(self):
         from stubo.service.api import update_delay_policy
+
         args = {
-          'delay_type' : 'weighted',
-          'name' : 'x',
-          'delays' : 'fixed,30000,5:normalvariate,1000,1000,15:normalvariate,500,1000,70'
+            'delay_type': 'weighted',
+            'name': 'x',
+            'delays': 'fixed,30000,5:normalvariate,1000,1000,15:normalvariate,500,1000,70'
         }
         response = update_delay_policy(self.make_request(), args)
         self.assertEqual(response['data']['message'],
-            "Put Delay Policy Finished")
-        self.assertEqual(self.cache.get_delay_policy('x'), 
+                         "Put Delay Policy Finished")
+        self.assertEqual(self.cache.get_delay_policy('x'),
                          {'delay_type': 'weighted', 'name': 'x',
-                          'delays' : 'fixed,30000,5:normalvariate,1000,1000,15:normalvariate,500,1000,70'})    
-           
+                          'delays': 'fixed,30000,5:normalvariate,1000,1000,15:normalvariate,500,1000,70'})
+
     def test_invalid_args(self):
         from stubo.service.api import update_delay_policy
         from stubo.exceptions import HTTPClientError
+
         args = {
-          'delay_type' : 'normalvariate',
-          'name' : 'x',
-          'milliseconds' : '700'
+            'delay_type': 'normalvariate',
+            'name': 'x',
+            'milliseconds': '700'
         }
         with self.assertRaises(HTTPClientError):
             update_delay_policy(self.make_request(), args)
@@ -1247,37 +1306,39 @@ class TestDelayPolicy(unittest.TestCase):
     def test_invalid_args2(self):
         from stubo.service.api import update_delay_policy
         from stubo.exceptions import HTTPClientError
+
         args = {
-          'delay_type' : 'fixed',
-          'name' : 'x',
-          'mean' : '700'
+            'delay_type': 'fixed',
+            'name': 'x',
+            'mean': '700'
         }
         with self.assertRaises(HTTPClientError):
             update_delay_policy(self.make_request(), args)
-            
+
     def test_invalid_args3(self):
         from stubo.service.api import update_delay_policy
         from stubo.exceptions import HTTPClientError
+
         args = {
             'delay_type': 'weighted',
             'name': 'x',
         }
         with self.assertRaises(HTTPClientError):
-            update_delay_policy(self.make_request(), args)   
-            
+            update_delay_policy(self.make_request(), args)
+
     def test_invalid_args4(self):
         from stubo.service.api import update_delay_policy
         from stubo.exceptions import HTTPClientError
+
         args = {
             'delay_type': 'weighted',
-           'delays': 'baddata',
+            'delays': 'baddata',
         }
         with self.assertRaises(HTTPClientError):
             update_delay_policy(self.make_request(), args)
 
 
 class TestBookmarks(unittest.TestCase):
-
     def setUp(self):
         self.cache = DummyCache('localhost')
         self.patch = mock.patch('stubo.service.api.Cache', self.cache)
@@ -1292,38 +1353,40 @@ class TestBookmarks(unittest.TestCase):
         self.patch.stop()
         self.db_patch.stop()
         self.db_patch2.stop()
-                    
-    def make_request(self, **settings):  
+
+    def make_request(self, **settings):
         return DummyRequestHandler(**settings)
-    
-    def _make_scenario(self, name,  **kwargs):
+
+    def _make_scenario(self, name, **kwargs):
         doc = dict(name=name, **kwargs)
         self.scenario.insert(**doc)
-        
+
     def test_put_no_request_index(self):
         from stubo.service.api import put_bookmark
         from stubo.exceptions import HTTPClientError
-        with self.assertRaises(HTTPClientError):  
+
+        with self.assertRaises(HTTPClientError):
             put_bookmark(self.make_request(), 'paul', 'save_paul')
-            
+
     def test_put_no_session(self):
         from stubo.service.api import put_bookmark
-        from stubo.exceptions import HTTPClientError 
-        with self.assertRaises(HTTPClientError): 
+        from stubo.exceptions import HTTPClientError
+
+        with self.assertRaises(HTTPClientError):
             put_bookmark(self.make_request(), 'bogus', 'xxx')
 
 
 class TestGetStatus(unittest.TestCase):
-    
     def test_call(self):
         from stubo.service.api import get_status
+
         response = get_status(DummyRequestHandler())
         self.assertEqual(response.keys(), ['version', 'data'])
-            
+
+
 from stubo.model.cmds import TextCommandsImporter
 
 
 class DummyStuboCommandFile(TextCommandsImporter):
-    
     def run_command(self, url, priority):
         return 200

--- a/stubo/testing.py
+++ b/stubo/testing.py
@@ -2,104 +2,105 @@
     :copyright: (c) 2015 by OpenCredo.
     :license: GPLv3, see LICENSE for more details.
 """
-import os.path
 import os
-from collections import defaultdict
 from tempfile import mkdtemp
 from tornado.util import ObjectDict
 from tornado.testing import AsyncHTTPTestCase
 from tornado.web import MissingArgumentError
+import time
 
 DummyModel = ObjectDict
 
+
 def testdb_name():
     import uuid
+
     dbname = str(uuid.uuid4())
-    return  'test_{0}'.format(dbname)
-    
+    return 'test_{0}'.format(dbname)
+
+
 class Base(AsyncHTTPTestCase):
-    
     def __init__(self, *args, **kwargs):
-        self.cfg = kwargs.pop('cfg', {}) 
-        super(Base, self).__init__(*args, **kwargs)  
+        self.cfg = kwargs.pop('cfg', {})
+        super(Base, self).__init__(*args, **kwargs)
 
     def setUp(self):
         super(Base, self).setUp()
         # the default settting of 5 secs is not enough for my old mac
         os.environ['ASYNC_TEST_TIMEOUT'] = '50'
-        
 
     def tearDown(self):
         from stubo.utils import setup_redis
-        self.redis_server.flushdb()  
-        cache_db = setup_redis(db=9+1)
+
+        self.redis_server.flushdb()
+        cache_db = setup_redis(db=9 + 1)
         cache_db.flushdb()
         self.db.connection.drop_database(self.testdb)
         self.app.settings['process_executor'].shutdown()
-        super(Base, self).tearDown() 
-              
+        super(Base, self).tearDown()
+
     def get_app(self):
         from tornado.ioloop import IOLoop
         from stubo.service.run_stubo import TornadoManager
         from stubo.utils import init_mongo, start_redis, init_ext_cache
+
         self.testdb = testdb_name()
 
         self.cfg.update({
-            'redis.host' : '127.0.0.1',
-            'redis.port' : 6379,
-            'redis.db' : 9,
-            'redis_master.host' : '127.0.0.1',
-            'redis_master.port' : 6379,
-            'redis_master.db' : 9,
-            'request_cache_limit' : 10,
-        })  
+            'redis.host': '127.0.0.1',
+            'redis.port': 6379,
+            'redis.db': 9,
+            'redis_master.host': '127.0.0.1',
+            'redis_master.port': 6379,
+            'redis_master.db': 9,
+            'request_cache_limit': 10,
+        })
 
         self.db = init_mongo({
-            'tz_aware' : True,
-            'db' : self.testdb
-            })
-        args = {'capped': True, 'size' : 100000}
+            'tz_aware': True,
+            'db': self.testdb
+        })
+        args = {'capped': True, 'size': 100000}
         self.db.create_collection("tracker", **args)
         self.db.tracker.create_index('start_time', -1)
 
         # install() asserts that its not been initialised so setting it directly
-        #self.io_loop.install() 
+        # self.io_loop.install()
         IOLoop._instance = self.io_loop
         tm = TornadoManager(os.environ.get('STUBO_CONFIG_FILE_PATH'))
         self.redis_server, _ = start_redis(self.cfg)
         tm.cfg['ext_cache'] = init_ext_cache(self.cfg)
         tm.cfg['mongo.db'] = self.testdb
         tm.cfg.update(self.cfg)
-        app = tm.get_app() 
+        app = tm.get_app()
         self.app = app
         from concurrent.futures import ProcessPoolExecutor
+
         self.app.settings['process_executor'] = ProcessPoolExecutor()
-        return app     
+        return app
 
 
-         
 class DummyRequestHandler(object):
-    
     application_url = 'http://example.com'
     host = 'example.com:80'
     _ARG_DEFAULT = []
 
     def __init__(self, request=None, **kwargs):
         super(DummyRequestHandler, self).__init__()
-        
+
         tmp_static_dir = mkdtemp()
         self.application = DummyModel(application_url=self.application_url,
                                       host=self.host,
                                       static_path=tmp_static_dir)
-        self.application.update(**kwargs)  
-        self.request = request or DummyModel(protocol='http', 
+        self.application.update(**kwargs)
+        self.request = request or DummyModel(protocol='http',
                                              host='localhost:8001',
                                              path='/',
                                              headers={},
                                              arguments=kwargs,
                                              body='')
         host, port = self.request.host.split(':')
-        self.track = DummyModel(host=host, server=host, port=port, 
+        self.track = DummyModel(host=host, server=host, port=port,
                                 tracking_level='normal',
                                 request_params=kwargs)
 
@@ -113,15 +114,15 @@ class DummyRequestHandler(object):
     def on_finish(self):
         """Called after the end of a request."""
         self._finish_time = time.time()
-        
+
     def get_argument(self, name, default=_ARG_DEFAULT, strip=True):
         args = self.get_arguments(name, strip=strip)
         if not args:
             if default is self._ARG_DEFAULT:
                 raise MissingArgumentError(name)
             return default
-        return args[-1]   
-    
+        return args[-1]
+
     def get_arguments(self, name, strip=True):
         """Returns a list of the arguments with the given name.
 
@@ -149,7 +150,7 @@ class DummyRequestHandler(object):
 
     def static_url(self, path):
         return os.path.join('/static', path)
-    
+
     def request_time(self):
         """Returns the amount of time it took for this request to execute."""
         if self._finish_time is None:
@@ -158,26 +159,25 @@ class DummyRequestHandler(object):
             return self._finish_time - self._start_time
 
 
-class DummyHash(object):     
-  
+class DummyHash(object):
     def __init__(self, keys=None):
         self._keys = keys or {}
-        
+
     def __call__(self, *args):
-        return self    
-    
+        return self
+
     def keys(self, name):
         return self._keys.get(name, {}).keys()
-    
+
     def remove(self, name):
         return self._keys.pop(name, None)
-    
+
     def exists(self, key, name):
         item = self._keys.get(key)
         if not item:
             return False
         return name in item
-    
+
     def delete(self, name, keys):
         item = self._keys.get(name)
         deleted = 0
@@ -185,50 +185,54 @@ class DummyHash(object):
             if isinstance(keys, basestring):
                 del item[keys]
                 deleted += 1
-            else:    
+            else:
                 for key in keys:
                     del item[key]
                     deleted += 1
             self._keys[name] = item
-        return deleted         
-    
+        return deleted
+
     def get_raw(self, name, key):
         value = self._keys.get(name, {}).get(key)
         return value
-      
+
     def get(self, name, key):
         import json
+
         try:
             return json.loads(self.get_raw(name, key))
         except TypeError:
             return None
-    
+
     def get_all_raw(self, name):
         return self._keys.get(name, {})
-        
+
     def get_all(self, name):
         import json
+
         result = self.get_all_raw(name)
         if result:
             result = dict((k, json.loads(v)) for k, v in result.iteritems())
-        return result  
-    
+        return result
+
     def values(self, name):
         import json
+
         result = self.get_all_raw(name)
         if result:
             result = [json.loads(v) for v in result.itervalues()]
-        return result             
-    
+        return result
+
     def set_raw(self, name, key, value):
         if name not in self._keys:
-            self._keys[name] = {}    
-        self._keys[name][key] = value 
-        
+            self._keys[name] = {}
+        self._keys[name][key] = value
+
     def set(self, name, key, value):
         import json
-        self.set_raw(name, key, json.dumps(value)) 
-        
+
+        self.set_raw(name, key, json.dumps(value))
+
     def incr(self, name, key, amount=1):
         val = self.get(name, key)
         if val:
@@ -236,105 +240,106 @@ class DummyHash(object):
         else:
             val = amount
         self.set(name, key, val)
-        return val  
-    
+        return val
+
+
 from stubo.cache import Cache
 from stubo.model.db import Scenario
 import ming
+
 mg = ming.create_datastore('mim://')
 
+
 class DummyScenario(Scenario):
-    
     def __init__(self):
         dbname = testdb_name()
         client = getattr(mg.conn, dbname)
         Scenario.__init__(self, db=client)
-        
+
     def __call__(self, **kwargs):
-        return self  
-    
-    # derive these methods as ming hasn't implemented '$regex' matching
-    
+        return self
+
+        # derive these methods as ming hasn't implemented '$regex' matching
+
     def get_all(self, name=None):
         if name and isinstance(name, dict) and '$regex' in name:
             # {'$regex': 'localhost:.*'}
             name = name['$regex'].partition(':')[0]
-            all_names =  list(Scenario.get_all(self))
+            all_names = list(Scenario.get_all(self))
             return [self.get(x.get('name')) for x in all_names if name in x.get('name')]
         else:
-            return Scenario.get_all(self, name=name)  
-        
-        
+            return Scenario.get_all(self, name=name)
+
     def get_stubs(self, name=None):
         if name and isinstance(name, dict) and '$regex' in name:
             name = name['$regex'].partition(':')[0]
-            all_names =  list(self.db.scenario_stub.find({}))
-            result =  [x for x in all_names if name in x.get('scenario')]
+            all_names = list(self.db.scenario_stub.find({}))
+            result = [x for x in all_names if name in x.get('scenario')]
         else:
-            result = Scenario.get_stubs(self, name=name)   
-        return result       
-    
+            result = Scenario.get_stubs(self, name=name)
+        return result
+
+
 class DummyCache(Cache):
-    
     def __init__(self, host):
         Cache.__init__(self, host)
-        self._hash =  DummyHash()
-    
+        self._hash = DummyHash()
+
     def __call__(self, host):
         self.host = host
-        return self    
-    
+        return self
+
     def hash_cls(self):
         return self._hash
-    
+
     def get_all_saved_request_index_data(self):
         return {}
-      
 
 
-        
 from collections import defaultdict
+
+
 class DummyQueue(object):
-    
     _data = defaultdict(list)
-     
+
     def __init__(self, name, server=None):
         self.name = name
-    
+
     def _get_list(self):
         return self._data[self.name]
-    
+
     def get(self, timeout=None):
-        return self._get_list().pop() 
-    
+        return self._get_list().pop()
+
     def get_item(self, index):
         return self._get_list()[index] if self._get_list() else None
 
     def put(self, msg):
-        self._get_list().append(msg) 
-        
+        self._get_list().append(msg)
+
     def delete(self):
-        self._data.pop(self.name, 0)         
-        
+        self._data.pop(self.name, 0)
+
     def __len__(self):
-        return len(self._get_list())           
-        
+        return len(self._get_list())
+
+
 class DummyTracker(object):
-    
     def __init__(self, db=None):
         # db should be similar to a multidict
         self.db = db or defaultdict(list)
-        
+
     def __call__(self, **kwargs):
-        return self      
-        
+        return self
+
     def insert(self, track):
         _id = track.get('_id')
         if not _id:
             import time
-            _id = int(time.time())          
+
+            _id = int(time.time())
         self.db[_id] = track
-    
+
     def find_tracker_data(self, tracker_filter, skip, limit):
         self.db['_filter'] = tracker_filter
         self.db['_skip'] = skip
@@ -343,25 +348,27 @@ class DummyTracker(object):
 
     def find_tracker_data_full(self, _id):
         return self.db.get(_id)
-    
+
     def session_last_used(self, scenario, session, mode):
         ''' Return the date this session was last used using the 
             last get/response time.
         '''
         import datetime
+
         return dict(start_time=datetime.datetime.now(),
-                    remote_ip='::1')  
-        
+                    remote_ip='::1')
+
     def get_last_playback(self, scenario, session, start_time):
         return self.db.values()
-    
+
     get_last_recording = get_last_playback
-    
+
+
 def make_stub(matchers, response, delay_policy=None, module=None,
               recorded=None):
     request = {
         "method": "POST",
-        "bodyPatterns": { "contains": matchers }
+        "bodyPatterns": {"contains": matchers}
     }
     response = {
         "status": 200,
@@ -370,19 +377,19 @@ def make_stub(matchers, response, delay_policy=None, module=None,
     if delay_policy:
         response['delayPolicy'] = delay_policy
     payload = {
-        "recorded" : recorded or '2014-05-20',       
+        "recorded": recorded or '2014-05-20',
         "request": request,
         "response": response,
     }
     if module:
         payload['module'] = module
-    return payload  
-    
+    return payload
+
+
 def make_cache_stub(matchers, response_ids, delay_policy=None, module=None,
                     recorded=None):
-    stub = make_stub(matchers, response_ids, delay_policy=delay_policy, 
+    stub = make_stub(matchers, response_ids, delay_policy=delay_policy,
                      module=module, recorded=recorded)
     stub['response'].pop('body')
     stub['response']['ids'] = response_ids
     return stub
- 

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1104,7 +1104,7 @@ class TestYAMLImport(Base):
         self.assertEqual(response.code, 200)
         
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_rest/rest.zip'), self.stop)
+            '/static/exports/localhost_rest/yaml_format/rest.zip'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         response = json.loads(response.body)
@@ -1112,8 +1112,7 @@ class TestYAMLImport(Base):
         self.assertEqual(response['data']['number_of_requests'], 5)
         
     def test_gzip_from_export(self):
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/rest/yaml/1.yaml'), self.stop)
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/tests/rest/yaml/1.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
@@ -1122,7 +1121,7 @@ class TestYAMLImport(Base):
         self.assertEqual(response.code, 200)
         
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_rest/rest.tar.gz'), self.stop)
+            '/static/exports/localhost_rest/yaml_format/rest.tar.gz'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         response = json.loads(response.body)
@@ -1179,7 +1178,7 @@ class TestCommandsImport(Base):
         self.assertEqual(response.code, 200)
         
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/first.zip'), self.stop)
+            '/static/exports/localhost_first/yaml_format/first.zip'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         
@@ -1202,7 +1201,7 @@ class TestCommandsImport(Base):
         self.assertEqual(response.code, 200)
         
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/first.tar.gz'), self.stop)
+            '/static/exports/localhost_first/yaml_format/first.tar.gz'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1540,10 +1540,10 @@ class TestTracker(Base):
         self.assertEqual(tracker['stubo_response'], "Hello 2 World")
 
         # not for minimal tracking as these can be big.
-        self.assertFalse(tracker.has_key('request_text'))
-        self.assertFalse(tracker.has_key('matchers'))
-        self.assertFalse(tracker.has_key('raw_response'))
-        self.assertFalse(tracker.has_key('encoded_response'))
+        self.assertFalse('request_text' in tracker)
+        self.assertFalse('matchers' in tracker)
+        self.assertFalse('raw_response' in tracker)
+        self.assertFalse('encoded_response' in tracker)
 
     def test_full_tracking_level(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -275,9 +275,9 @@ class TestExport(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertTrue('links' in payload['data'])
-        self.assertEqual(5, len(payload['data']['links']))
-        self.assertEqual(1, len([x for x in payload['data']['links'] \
+        self.assertTrue('yaml_links' in payload['data'])
+        self.assertEqual(5, len(payload['data']['yaml_links']))
+        self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
                                 if x[0] == 'first.yaml']))
         
         
@@ -289,7 +289,7 @@ class TestExport(Base):
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/first.yaml'), self.stop)
+            '/static/exports/localhost_first/yaml_format/first.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         
@@ -344,15 +344,15 @@ class TestExport(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertTrue('links' in payload['data'])
+        self.assertTrue('yaml_links' in payload['data'])
      
-        self.assertEqual(7, len(payload['data']['links']))
+        self.assertEqual(7, len(payload['data']['yaml_links']))
         self.assertTrue('runnable' in payload['data'])
         runnable = payload['data']['runnable']
         self.assertEqual(runnable.get('playback_session'),  'first_1')
         self.assertEqual(runnable.get('number_of_playback_requests'), 1)
         
-        self.assertEqual(1, len([x for x in payload['data']['links'] \
+        self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
                                 if x[0] == 'first.yaml']))
         self.http_client.fetch(self.get_url(
                                '/stubo/api/delete/stubs?scenario=first'),
@@ -362,7 +362,7 @@ class TestExport(Base):
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/first.yaml'), self.stop)
+            '/static/exports/localhost_first/yaml_format/first.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
              
@@ -387,14 +387,14 @@ class TestExport(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertTrue('links' in payload['data'])
+        self.assertTrue('yaml_links' in payload['data'])
      
-        self.assertEqual(7, len(payload['data']['links']))
+        self.assertEqual(7, len(payload['data']['yaml_links']))
         self.assertTrue('runnable' in payload['data'])
         runnable = payload['data']['runnable']
         self.assertEqual(runnable.get('playback_session'),  'first_1')
         self.assertEqual(runnable.get('number_of_playback_requests'), 1)
-        self.assertEqual(1, len([x for x in payload['data']['links'] \
+        self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
                                 if x[0] == 'first.yaml']))
         self.http_client.fetch(self.get_url(
                                '/stubo/api/delete/stubs?scenario=first'),
@@ -404,7 +404,7 @@ class TestExport(Base):
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/first.yaml'), self.stop)
+            '/static/exports/localhost_first/yaml_format/first.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)               
         
@@ -419,13 +419,13 @@ class TestExport(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertTrue('links' in payload['data'])
-        self.assertEqual(7, len(payload['data']['links']))
+        self.assertTrue('yaml_links' in payload['data'])
+        self.assertEqual(7, len(payload['data']['yaml_links']))
         self.assertTrue('runnable' in payload['data'])
         runnable = payload['data']['runnable']
         self.assertEqual(runnable.get('playback_session'),  'multi_play_2')
         self.assertEqual(runnable.get('number_of_playback_requests'), 1)
-        self.assertEqual(1, len([x for x in payload['data']['links'] \
+        self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
                                 if x[0] == 'multi_play.yaml']))
         self.http_client.fetch(self.get_url(
                                '/stubo/api/delete/stubs?scenario=multi_play'),
@@ -435,7 +435,7 @@ class TestExport(Base):
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_multi_play/multi_play.yaml'), self.stop)
+            '/static/exports/localhost_multi_play/yaml_format/multi_play.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200) 
         
@@ -450,14 +450,14 @@ class TestExport(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertTrue('links' in payload['data'])
-        self.assertEqual(15, len(payload['data']['links']))
+        self.assertTrue('yaml_links' in payload['data'])
+        self.assertEqual(15, len(payload['data']['yaml_links']))
         self.assertTrue('runnable' in payload['data'])
         runnable = payload['data']['runnable']
         self.assertEqual(runnable.get('playback_session'),  'multi_play_2')
         self.assertEqual(runnable.get('number_of_playback_requests'), 5)
         
-        self.assertEqual(1, len([x for x in payload['data']['links'] \
+        self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
                                 if x[0] == 'multi_play.yaml']))
         self.http_client.fetch(self.get_url(
                                '/stubo/api/delete/stubs?scenario=multi_play'),
@@ -467,7 +467,7 @@ class TestExport(Base):
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-            '/static/exports/localhost_multi_play/multi_play.yaml'), self.stop)
+            '/static/exports/localhost_multi_play/yaml_format/multi_play.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)            
         
@@ -492,7 +492,7 @@ class TestExport(Base):
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_mangler_xslt/mangler_xslt.yaml'),
+            '/static/exports/localhost_mangler_xslt/yaml_format/mangler_xslt.yaml'),
                                self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)  
@@ -1131,7 +1131,7 @@ class TestYAMLImport(Base):
         
     def test_post_exec_cmds(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_rest/rest.yaml'), callback=self.stop, 
+            '/static/exports/localhost_rest/yaml_format/rest.yaml'), callback=self.stop,
                                method="POST", body="")
         response = self.wait()
         self.assertEqual(response.code, 200)   

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -2,19 +2,19 @@
 import json
 from stubo.testing import Base
 
-class TestPutDelay(Base):   
 
+class TestPutDelay(Base):
     def test_put_fixed(self):
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-                               'name=rtz_1&delay_type=fixed&milliseconds=700'),
+                                            'name=rtz_1&delay_type=fixed&milliseconds=700'),
                                self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         payload = json.loads(response.body)
-        expect = {"version": self.app.settings.get('stubo_version'), 
-                  "data": {"message": "Put Delay Policy Finished", 
+        expect = {"version": self.app.settings.get('stubo_version'),
+                  "data": {"message": "Put Delay Policy Finished",
                            u'status': 'new', "delay_type": "fixed",
                            "name": "rtz_1"}}
         self.assertEqual(payload, expect)
@@ -22,16 +22,16 @@ class TestPutDelay(Base):
 
     def test_put_normalvariate(self):
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-            'name=rtz_2&delay_type=normalvariate&mean=100&stddev=50'),
+                                            'name=rtz_2&delay_type=normalvariate&mean=100&stddev=50'),
                                self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         payload = json.loads(response.body)
-        expect = {"version": self.app.settings.get('stubo_version'), 
-                  "data": {"message": "Put Delay Policy Finished", 
-                           u'status': 'new', "delay_type": "normalvariate", 
+        expect = {"version": self.app.settings.get('stubo_version'),
+                  "data": {"message": "Put Delay Policy Finished",
+                           u'status': 'new', "delay_type": "normalvariate",
                            "name": "rtz_2"}}
         self.assertEqual(payload, expect)
         self.assertTrue(int(response.request_time) < 5)
@@ -39,66 +39,66 @@ class TestPutDelay(Base):
     def test_update_delay(self):
         from stubo.cache import Hash
         from stubo.cache.queue import get_redis_master
+
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-            'name=x&delay_type=fixed&milliseconds=7'), self.stop)
+                                            'name=x&delay_type=fixed&milliseconds=7'), self.stop)
         self.wait()
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-                               'name=x&delay_type=fixed&milliseconds=8'),
+                                            'name=x&delay_type=fixed&milliseconds=8'),
                                self.stop)
         response = self.wait()
-        delay_policy = Hash(get_redis_master()).get('localhost:delay_policy', 'x') 
+        delay_policy = Hash(get_redis_master()).get('localhost:delay_policy', 'x')
         self.assertTrue(delay_policy['milliseconds'], 8)
-        expect = {"version": self.app.settings.get('stubo_version'), 
-                  "data": {"message": "Put Delay Policy Finished", 
-                           u'status': 'updated', "delay_type": "fixed", 
+        expect = {"version": self.app.settings.get('stubo_version'),
+                  "data": {"message": "Put Delay Policy Finished",
+                           u'status': 'updated', "delay_type": "fixed",
                            "name": "x"}}
         payload = json.loads(response.body)
-        self.assertEqual(payload, expect)   
-                     
+        self.assertEqual(payload, expect)
 
     def test_get_one_delay_policy(self):
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-                               'name=rtz_1&delay_type=fixed&milliseconds=700'),
+                                            'name=rtz_1&delay_type=fixed&milliseconds=700'),
                                self.stop)
         response = self.wait()
         self.http_client.fetch(self.get_url('/stubo/api/get/delay_policy?'
                                             'name=rtz_1'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         payload = json.loads(response.body)
-        expect = {"version": self.app.settings.get('stubo_version'), 
-                  'data': {'delay_type': 'fixed','milliseconds': '700',
+        expect = {"version": self.app.settings.get('stubo_version'),
+                  'data': {'delay_type': 'fixed', 'milliseconds': '700',
                            'name': 'rtz_1'}}
         self.assertEqual(payload, expect)
         self.assertTrue(int(response.request_time) < 5)
 
     def test_get_many_delay_policies(self):
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-                               'name=rtz_1&delay_type=fixed&milliseconds=700'),
+                                            'name=rtz_1&delay_type=fixed&milliseconds=700'),
                                self.stop)
         response = self.wait()
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-            'name=rtz_2&delay_type=normalvariate&mean=100&stddev=50'), 
+                                            'name=rtz_2&delay_type=normalvariate&mean=100&stddev=50'),
                                self.stop)
         response = self.wait()
         self.http_client.fetch(self.get_url('/stubo/api/get/delay_policy'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         payload = json.loads(response.body)
         expect = {"version": self.app.settings.get('stubo_version'),
                   "data": {"rtz_1": {"delay_type": "fixed", "name": "rtz_1",
-                                     "milliseconds": "700"}, 
-                  "rtz_2": {"delay_type": "normalvariate", "name": "rtz_2",
-                            "stddev": "50", "mean": "100"}}}
+                                     "milliseconds": "700"},
+                           "rtz_2": {"delay_type": "normalvariate", "name": "rtz_2",
+                                     "stddev": "50", "mean": "100"}}}
         self.assertEqual(payload, expect)
         self.assertTrue(int(response.request_time) < 5)
 
-class TestAcceptance(Base):  
 
+class TestAcceptance(Base):
     def test_exec_first_commands(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
                                             '/static/cmds/demo/first.commands'),
@@ -106,8 +106,8 @@ class TestAcceptance(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        stubo_response = self.db.tracker.find_one({'function':'get/response'},
-                             {'stubo_response':1})['stubo_response']
+        stubo_response = self.db.tracker.find_one({'function': 'get/response'},
+                                                  {'stubo_response': 1})['stubo_response']
         self.assertEqual('Hello 2 World\n', stubo_response)
         cmds = ['delete/stubs?scenario=first',
                 'begin/session?scenario=first&session=first_1&mode=record',
@@ -119,97 +119,98 @@ class TestAcceptance(Base):
         for cmd in cmds:
             self.assertTrue(cmd in response.body)
 
+
 class TestRequestCacheLimit(Base):
-    
     def test_cached_requests_are_in_limit(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-            '/static/cmds/tests/request_cache_limit/1.commands'), self.stop)
+                                            '/static/cmds/tests/request_cache_limit/1.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         from stubo.cache.queue import Hash
+
         keys = Hash(self.redis_server).keys(
             'localhost:request_cache_limit:request')
         self.assertEqual(len(keys), self.cfg['request_cache_limit'])
-        
-class TestBigResponse(Base):  
 
+
+class TestBigResponse(Base):
     def test_exec_first_commands(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/tests/big/big.commands'),
+                                            '/static/cmds/tests/big/big.commands'),
                                self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-class TestDelays(Base):
 
+class TestDelays(Base):
     def test_delay(self):
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-            'name=delay_1&delay_type=fixed&milliseconds=1000'), self.stop)
+                                            'name=delay_1&delay_type=fixed&milliseconds=1000'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/demo/first_setup.commands'), self.stop)
+                                            '/static/cmds/demo/first_setup.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/response?session=first_1'),
-                               callback=self.stop, method="POST",
-                               body="get my stub")
+            '/stubo/api/get/response?session=first_1'),
+            callback=self.stop, method="POST",
+            body="get my stub")
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.assertTrue(float(response.request_time) > 0.999)
 
     def test_changing_delay(self):
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-            'name=delay_1&delay_type=fixed&milliseconds=500'), self.stop)
+                                            'name=delay_1&delay_type=fixed&milliseconds=500'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/demo/first_setup.commands'), self.stop)
+                                            '/static/cmds/demo/first_setup.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?'
-            'name=delay_1&delay_type=fixed&milliseconds=70'), self.stop)
+                                            'name=delay_1&delay_type=fixed&milliseconds=70'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/response?session=first_1'),
-                               callback=self.stop, method="POST",
-                               body="get my stub")
+            '/stubo/api/get/response?session=first_1'),
+            callback=self.stop, method="POST",
+            body="get my stub")
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.assertTrue(float(response.request_time) > 0.069)
-        
-    def test_delete(self): 
+
+    def test_delete(self):
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?name='
-                               'delay_1&delay_type=fixed&milliseconds=500'),
+                                            'delay_1&delay_type=fixed&milliseconds=500'),
                                self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/delete/delay_policy?name=delay_1'),
-                               self.stop)
+            '/stubo/api/delete/delay_policy?name=delay_1'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/get/delay_policy'),
                                self.stop)
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         payload = json.loads(response.body)
         self.assertEqual(payload['data'], {})
-        
-    def test_mulitiple_delete(self): 
+
+    def test_mulitiple_delete(self):
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?name='
-            'delay_1&delay_type=fixed&milliseconds=500'), self.stop)
+                                            'delay_1&delay_type=fixed&milliseconds=500'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?name='
-            'delay_2&delay_type=fixed&milliseconds=500'), self.stop)
+                                            'delay_2&delay_type=fixed&milliseconds=500'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/delete/delay_policy'),
@@ -218,204 +219,203 @@ class TestDelays(Base):
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/get/delay_policy'), self.stop)
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         payload = json.loads(response.body)
-        self.assertEqual(payload['data'], {}) 
-        
-    def test_mulitiple_delete_by_name(self): 
+        self.assertEqual(payload['data'], {})
+
+    def test_mulitiple_delete_by_name(self):
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?name='
-            'delay_1&delay_type=fixed&milliseconds=500'), self.stop)
+                                            'delay_1&delay_type=fixed&milliseconds=500'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/put/delay_policy?name='
-            'delay_2&delay_type=fixed&milliseconds=500'), self.stop)
+                                            'delay_2&delay_type=fixed&milliseconds=500'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/delete/delay_policy?'
-                               'name=delay_1&name=delay_2'), self.stop)
+                                            'name=delay_1&name=delay_2'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/get/delay_policy'),
                                self.stop)
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         payload = json.loads(response.body)
-        self.assertEqual(payload['data'], {})             
+        self.assertEqual(payload['data'], {})
+
 
 class TestMatching(Base):
-
     def test_no_match_found(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/tests/accept/matcher1.commands'),
+                                            '/static/cmds/tests/accept/matcher1.commands'),
                                self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        stubo_responses = self.db.tracker.find({'function':'get/response'})
+        stubo_responses = self.db.tracker.find({'function': 'get/response'})
         sr = []
         for resp in stubo_responses:
-            sr.append(resp['stubo_response']) 
-        self.assertEqual(2,len(sr))
+            sr.append(resp['stubo_response'])
+        self.assertEqual(2, len(sr))
         self.assertEqual('Hello from advanced matching.\n', sr[0])
         self.assertTrue('error' in sr[1])
         self.assertEqual('E017:No matching response found',
                          sr[1]['error']['message'])
 
+
 class TestExport(Base):
-    
     def test_export(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-                               '/static/cmds/demo/first.commands'), self.stop)
+                                            '/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/export?scenario=first'),
-                               self.stop)
+            '/stubo/api/get/export?scenario=first'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
         self.assertTrue('yaml_links' in payload['data'])
         self.assertEqual(5, len(payload['data']['yaml_links']))
         self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
-                                if x[0] == 'first.yaml']))
-        
-        
+                                 if x[0] == 'first.yaml']))
+
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/delete/stubs?scenario=first'),
-                               self.stop)
+            '/stubo/api/delete/stubs?scenario=first'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/yaml_format/first.yaml'), self.stop)
+                                            '/static/exports/localhost_first/yaml_format/first.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
     def test_export_order(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/tests/exports/ordering/order.commands'), self.stop)
+                                            '/static/cmds/tests/exports/ordering/order.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-       
-        
+
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/export?scenario=order&session_id=x'),
-                               self.stop)
+            '/stubo/api/get/export?scenario=order&session_id=x'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
         import os
+
         export_lines = []
         export_dir = payload['data']['export_dir_path']
 
         with open(os.path.join(export_dir, 'order.yaml')) as f:
-            export_lines = [x.strip() for x in f.readlines()] 
-        
+            export_lines = [x.strip() for x in f.readlines()]
+
         self.assertEqual(export_lines[2:], [
-         'recording:', 
-         'scenario: order', 
-         "session: '{{session}}'", 
-         'stubs:', 
-         '- file: order_x_0.json', 
-         '- file: order_x_1.json', 
-         '- file: order_x_2.json'])
-        for stub_no in [0,1,2]:
-            file_path = os.path.join(export_dir, 
+            'recording:',
+            'scenario: order',
+            "session: '{{session}}'",
+            'stubs:',
+            '- file: order_x_0.json',
+            '- file: order_x_1.json',
+            '- file: order_x_2.json'])
+        for stub_no in [0, 1, 2]:
+            file_path = os.path.join(export_dir,
                                      'order_x_{0}.json'.format(stub_no))
             with open(file_path) as f:
                 stub = json.loads(f.read())
                 self.assertEqual(stub.get('request').get('bodyPatterns').get(
-                                            'contains')[0], str(stub_no))    
-        
+                    'contains')[0], str(stub_no))
+
     def test_runnable_export(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=tracking_level&value=full'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)   
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-                               '/static/cmds/demo/first.commands'), self.stop)
+                                            '/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/export?scenario=first&runnable=true&playback_session=first_1'),
-                               self.stop)
+            '/stubo/api/get/export?scenario=first&runnable=true&playback_session=first_1'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
         self.assertTrue('yaml_links' in payload['data'])
-     
+
         self.assertEqual(7, len(payload['data']['yaml_links']))
         self.assertTrue('runnable' in payload['data'])
         runnable = payload['data']['runnable']
-        self.assertEqual(runnable.get('playback_session'),  'first_1')
+        self.assertEqual(runnable.get('playback_session'), 'first_1')
         self.assertEqual(runnable.get('number_of_playback_requests'), 1)
-        
+
         self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
-                                if x[0] == 'first.yaml']))
+                                 if x[0] == 'first.yaml']))
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/delete/stubs?scenario=first'),
-                               self.stop)
+            '/stubo/api/delete/stubs?scenario=first'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/yaml_format/first.yaml'), self.stop)
+                                            '/static/exports/localhost_first/yaml_format/first.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-             
-        
+
     def test_runnable_export2(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=tracking_level&value=full'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)   
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/demo/first.commands'), self.stop)
+                                            '/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/demo/first.commands'), self.stop)
+                                            '/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/export?scenario=first&runnable=true&playback_session=first_1'),
-                               self.stop)
+            '/stubo/api/get/export?scenario=first&runnable=true&playback_session=first_1'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
         self.assertTrue('yaml_links' in payload['data'])
-     
+
         self.assertEqual(7, len(payload['data']['yaml_links']))
         self.assertTrue('runnable' in payload['data'])
         runnable = payload['data']['runnable']
-        self.assertEqual(runnable.get('playback_session'),  'first_1')
+        self.assertEqual(runnable.get('playback_session'), 'first_1')
         self.assertEqual(runnable.get('number_of_playback_requests'), 1)
         self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
-                                if x[0] == 'first.yaml']))
+                                 if x[0] == 'first.yaml']))
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/delete/stubs?scenario=first'),
-                               self.stop)
+            '/stubo/api/delete/stubs?scenario=first'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/yaml_format/first.yaml'), self.stop)
+                                            '/static/exports/localhost_first/yaml_format/first.yaml'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)               
-        
+        self.assertEqual(response.code, 200)
+
     def test_runnable_export_found(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/tests/accept/multi_play.commands&nplays=1&nsessions=5'), self.stop)
+                                            '/static/cmds/tests/accept/multi_play.commands&nplays=1&nsessions=5'),
+                               self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/export?scenario=multi_play&runnable=true&playback_session=multi_play_2'),
-                               self.stop)
+            '/stubo/api/get/export?scenario=multi_play&runnable=true&playback_session=multi_play_2'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
@@ -423,30 +423,32 @@ class TestExport(Base):
         self.assertEqual(7, len(payload['data']['yaml_links']))
         self.assertTrue('runnable' in payload['data'])
         runnable = payload['data']['runnable']
-        self.assertEqual(runnable.get('playback_session'),  'multi_play_2')
+        self.assertEqual(runnable.get('playback_session'), 'multi_play_2')
         self.assertEqual(runnable.get('number_of_playback_requests'), 1)
         self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
-                                if x[0] == 'multi_play.yaml']))
+                                 if x[0] == 'multi_play.yaml']))
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/delete/stubs?scenario=multi_play'),
-                               self.stop)
+            '/stubo/api/delete/stubs?scenario=multi_play'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_multi_play/yaml_format/multi_play.yaml'), self.stop)
+                                            '/static/exports/localhost_multi_play/yaml_format/multi_play.yaml'),
+                               self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
-        
+        self.assertEqual(response.code, 200)
+
     def test_runnable_export_found2(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/tests/accept/multi_play.commands&nplays=5&nsessions=5'), self.stop)
+                                            '/static/cmds/tests/accept/multi_play.commands&nplays=5&nsessions=5'),
+                               self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/export?scenario=multi_play&runnable=true&playback_session=multi_play_2'),
-                               self.stop)
+            '/stubo/api/get/export?scenario=multi_play&runnable=true&playback_session=multi_play_2'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
@@ -454,27 +456,28 @@ class TestExport(Base):
         self.assertEqual(15, len(payload['data']['yaml_links']))
         self.assertTrue('runnable' in payload['data'])
         runnable = payload['data']['runnable']
-        self.assertEqual(runnable.get('playback_session'),  'multi_play_2')
+        self.assertEqual(runnable.get('playback_session'), 'multi_play_2')
         self.assertEqual(runnable.get('number_of_playback_requests'), 5)
-        
+
         self.assertEqual(1, len([x for x in payload['data']['yaml_links'] \
-                                if x[0] == 'multi_play.yaml']))
+                                 if x[0] == 'multi_play.yaml']))
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/delete/stubs?scenario=multi_play'),
-                               self.stop)
+            '/stubo/api/delete/stubs?scenario=multi_play'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-            '/static/exports/localhost_multi_play/yaml_format/multi_play.yaml'), self.stop)
+                                            '/static/exports/localhost_multi_play/yaml_format/multi_play.yaml'),
+                               self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)            
-        
+        self.assertEqual(response.code, 200)
+
     def test_export_module(self):
         # load some stubs
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/ext/xslt/first.commands'), self.stop)
+                                            '/static/cmds/tests/ext/xslt/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
@@ -492,17 +495,17 @@ class TestExport(Base):
 
         # load from the export
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_mangler_xslt/yaml_format/mangler_xslt.yaml'),
+                                            '/static/exports/localhost_mangler_xslt/yaml_format/mangler_xslt.yaml'),
                                self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)  
-    
-class TestGeneralFunctionality(Base):     
+        self.assertEqual(response.code, 200)
 
+
+class TestGeneralFunctionality(Base):
     def test_stub_count(self):
         # load some stubs
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/demo/first.commands'), self.stop)
+                                            '/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
@@ -512,28 +515,28 @@ class TestGeneralFunctionality(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        expect = {"version": self.app.settings.get('stubo_version'), 
-                  "data": {"count": 1, "scenario":"first", "host" : "localhost"}}
+        expect = {"version": self.app.settings.get('stubo_version'),
+                  "data": {"count": 1, "scenario": "first", "host": "localhost"}}
         self.assertEqual(payload, expect)
-        
+
     def test_stub_count_with_host(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/stubcount?host=another'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        expect = {"version": self.app.settings.get('stubo_version'), 
-                  "data": {"count": 0, "scenario": "all", "host" : "another"}}
-        self.assertEqual(payload, expect)    
+        expect = {"version": self.app.settings.get('stubo_version'),
+                  "data": {"count": 0, "scenario": "all", "host": "another"}}
+        self.assertEqual(payload, expect)
 
     def test_stub_count_all_scenarios(self):
         # load some stubs
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/demo/first.commands'), self.stop)
+                                            '/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/tests/accept/matcher1.commands'),
+                                            '/static/cmds/tests/accept/matcher1.commands'),
                                self.stop)
         response = self.wait()
 
@@ -543,8 +546,8 @@ class TestGeneralFunctionality(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        expect = {"version": self.app.settings.get('stubo_version'), 
-                  "data": {"count": 2, "scenario": "all", "host" : "localhost"}}
+        expect = {"version": self.app.settings.get('stubo_version'),
+                  "data": {"count": 2, "scenario": "all", "host": "localhost"}}
         self.assertEqual(payload, expect)
 
     def test_get_status(self):
@@ -552,17 +555,17 @@ class TestGeneralFunctionality(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        expect = {"version": self.app.settings.get('stubo_version'), 
-                  "data": {"cache_server": {"status": "ok", "local": True}, 
-                  "info": {
-                           "cluster": self.app.settings.get('cluster_name'),
-                           "graphite_host" : self.app.settings.get('graphite.host'),
-                  }, "database_server": {"status": "ok"}}}
+        expect = {"version": self.app.settings.get('stubo_version'),
+                  "data": {"cache_server": {"status": "ok", "local": True},
+                           "info": {
+                               "cluster": self.app.settings.get('cluster_name'),
+                               "graphite_host": self.app.settings.get('graphite.host'),
+                           }, "database_server": {"status": "ok"}}}
         self.assertEqual(payload, expect)
 
     def test_get_scenario_status(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
+                                            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
@@ -571,19 +574,19 @@ class TestGeneralFunctionality(Base):
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        
-        expect = {"version": self.app.settings.get('stubo_version'), 
-                  "data": {"cache_server": {"status": "ok", "local": True}, 
-                  "info": {
-                      "cluster": self.app.settings.get('cluster_name'),
-                      "graphite_host" : self.app.settings.get('graphite.host'),
-                  }, "database_server": {"status": "ok"}, 
-                  "sessions": [[u'first_1', u'playback']]}}
+
+        expect = {"version": self.app.settings.get('stubo_version'),
+                  "data": {"cache_server": {"status": "ok", "local": True},
+                           "info": {
+                               "cluster": self.app.settings.get('cluster_name'),
+                               "graphite_host": self.app.settings.get('graphite.host'),
+                           }, "database_server": {"status": "ok"},
+                           "sessions": [[u'first_1', u'playback']]}}
         self.assertEqual(payload, expect)
 
     def test_get_session_status(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
+                                            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
@@ -605,8 +608,8 @@ class TestGeneralFunctionality(Base):
         expect = {"version": self.app.settings.get('stubo_version')}
         self.assertEqual(payload, expect)
 
+
 class TestGetResponseWithHTTPHeaders(Base):
- 
     def test_get_not_supported(self):
         self.http_client.fetch(self.get_url('/stubo/api/get/response/foobar'),
                                self.stop)
@@ -616,133 +619,133 @@ class TestGetResponseWithHTTPHeaders(Base):
     def test_post_missing_stb_session(self):
         self.http_client.fetch(self.get_url('/stubo/api/get/response/foobar'),
                                callback=self.stop,
-            method="POST", body="hello")
+                               method="POST", body="hello")
 
         response = self.wait()
         self.assertEqual(response.code, 400)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         payload = json.loads(response.body)
         self.assertEqual("session not supplied in headers.",
-                        payload['error']['message'])
+                         payload['error']['message'])
 
     def test_post_fails_if_session_not_found(self):
         self.http_client.fetch(self.get_url('/stubo/api/get/response/foobar'),
                                callback=self.stop, method="POST", body="hello",
-                               headers={'ba_stb_session' : 'bar',
-                                        'ba_stb_scenario' : 'foo'})
+                               headers={'ba_stb_session': 'bar',
+                                        'ba_stb_scenario': 'foo'})
         response = self.wait()
         self.assertEqual(response.code, 400)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         payload = json.loads(response.body)
         # shows its extracted the session from the header 
         self.assertEqual("session not found - localhost:foo_bar",
-                        payload['error']['message'])
+                         payload['error']['message'])
 
     def test_post_ok(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/demo/first_setup.commands'), self.stop)
+                                            '/static/cmds/demo/first_setup.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        self.http_client.fetch(self.get_url('/stubo/api/get/response/foobar'), 
-                               callback=self.stop,  method="POST",
+        self.http_client.fetch(self.get_url('/stubo/api/get/response/foobar'),
+                               callback=self.stop, method="POST",
                                body="get my stub", headers={
-                               'ba_stb_scenario' : 'first',
-                               'ba_stb_session' : '1'})
+                'ba_stb_scenario': 'first',
+                'ba_stb_session': '1'})
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.assertIn("Hello 2 World", response.body)
-        
+
     def test_post_missing_stb_scenario(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/demo/first_setup.commands'), self.stop)
+                                            '/static/cmds/demo/first_setup.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         self.http_client.fetch(self.get_url('/stubo/api/get/response/foobar'),
                                callback=self.stop, method="POST",
                                body="get my stub",
-                               headers={'ba_stb_session' : 'first_1'})
+                               headers={'ba_stb_session': 'first_1'})
         response = self.wait()
         self.assertEqual(response.code, 400)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
+        payload = json.loads(response.body)
         # shows its extracted the session from the header 
         self.assertEqual("scenario parameter not supplied in headers.",
                          payload['error']['message'])
-        
+
     def test_url_param_takes_precedence(self):
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/response/foobar?session=pickme'), 
-                               callback=self.stop,  method="POST",
-                               body="get my stub", headers={
-                               'ba_stb_scenario' : 'first',
-                               'ba_stb_session' : '1'})
+            '/stubo/api/get/response/foobar?session=pickme'),
+            callback=self.stop, method="POST",
+            body="get my stub", headers={
+                'ba_stb_scenario': 'first',
+                'ba_stb_session': '1'})
         response = self.wait()
         payload = json.loads(response.body)
         self.assertEqual("session not found - localhost:pickme",
-                        payload['error']['message'])
-    
-class TestUseRequestInResponse(Base):
+                         payload['error']['message'])
 
-     def test_post_request_in_response_ok(self):
+
+class TestUseRequestInResponse(Base):
+    def test_post_request_in_response_ok(self):
         '''Pick up the request text for use in the stubbed response'''
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
+                                            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)       
+        self.assertEqual(response.code, 200)
 
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/response?session=first_1'),
-                               callback=self.stop, method="POST",
-                               body="<userid>abc123</userid>")
+            '/stubo/api/get/response?session=first_1'),
+            callback=self.stop, method="POST",
+            body="<userid>abc123</userid>")
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.assertIn("Hello to abc123", response.body)
 
+
 class TestEncoding(Base):
-        
     def test_utf8_in_all(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/encoding/utf8all.yaml'), self.stop)
+                                            '/static/cmds/tests/encoding/utf8all.yaml'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)      
-        stubo_response = self.db.tracker.find_one({'function':'get/response'},
-            {'stubo_response':1})['stubo_response']
-        self.assertTrue(u'A*\xa3$' in stubo_response)    
+        self.assertEqual(response.code, 200)
+        stubo_response = self.db.tracker.find_one({'function': 'get/response'},
+                                                  {'stubo_response': 1})['stubo_response']
+        self.assertTrue(u'A*\xa3$' in stubo_response)
+
 
 class TestTextEncoding(Base):
-
     def test_utf8_request(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-                               '/static/cmds/tests/encoding/text/1.commands'),
+                                            '/static/cmds/tests/encoding/text/1.commands'),
                                self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)      
-        stubo_response = self.db.tracker.find_one({'function':'get/response'},
-            {'stubo_response':1})['stubo_response']
+        self.assertEqual(response.code, 200)
+        stubo_response = self.db.tracker.find_one({'function': 'get/response'},
+                                                  {'stubo_response': 1})['stubo_response']
         self.assertEqual('hello', stubo_response)
-        
+
     def test_utf8_in_all(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/encoding/text/utf8_in_all.commands'), self.stop)
+                                            '/static/cmds/tests/encoding/text/utf8_in_all.commands'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)      
-        stubo_response = self.db.tracker.find_one({'function':'get/response'},
-            {'stubo_response':1})['stubo_response']
-        self.assertTrue(u'A*\xa3$' in stubo_response)                       
+        self.assertEqual(response.code, 200)
+        stubo_response = self.db.tracker.find_one({'function': 'get/response'},
+                                                  {'stubo_response': 1})['stubo_response']
+        self.assertTrue(u'A*\xa3$' in stubo_response)
+
 
 class TestPrivateVirtualStubo(Base):
-    
     def get_url(self, path, host=None):
         host = host or 'localhost'
         """Returns an absolute url for the given path on the test server."""
         return '%s://%s:%s%s' % (self.get_protocol(), host,
-                                self.get_http_port(), path)
-   
+                                 self.get_http_port(), path)
+
     def test_virtual_host(self):
         # start a session 'first' in playback mode on localhost,
         # localhost get/status should  show the session
@@ -750,167 +753,112 @@ class TestPrivateVirtualStubo(Base):
         # localhost get/response should works
         # 127.0.0.1 get/response should fail
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
+                                            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
-        self.assertEqual(response.code, 200)       
+        payload = json.loads(response.body)
+        self.assertEqual(response.code, 200)
 
         self.http_client.fetch(
-          self.get_url('/stubo/api/get/status?session=first_1'), self.stop)                       
+            self.get_url('/stubo/api/get/status?session=first_1'), self.stop)
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
-        self.assertEqual(response.code, 200)  
-        self.assertEqual(payload['data']['session'].get('status'), 'playback')     
+        payload = json.loads(response.body)
+        self.assertEqual(response.code, 200)
+        self.assertEqual(payload['data']['session'].get('status'), 'playback')
 
         self.http_client.fetch(
-          self.get_url('/stubo/api/get/status?session=first_1', 
-                       host='127.0.0.1'), self.stop)
+            self.get_url('/stubo/api/get/status?session=first_1',
+                         host='127.0.0.1'), self.stop)
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
-        self.assertEqual(response.code, 200)       
+        payload = json.loads(response.body)
+        self.assertEqual(response.code, 200)
         self.assertEqual(payload['data']['session'], {})
-        
 
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/response?session=first_1'), callback=self.stop,
-            method="POST", body="get my stub")   
+            method="POST", body="get my stub")
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.assertIn("Hello 2 World", response.body)
 
         self.http_client.fetch(
-          self.get_url('/stubo/api/get/response?session=first_1', 
-                       host='127.0.0.1'), callback=self.stop,
-          method="POST", body="get my stub")
+            self.get_url('/stubo/api/get/response?session=first_1',
+                         host='127.0.0.1'), callback=self.stop,
+            method="POST", body="get my stub")
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
         self.assertEqual(response.code, 400)
-        payload = json.loads(response.body) 
+        payload = json.loads(response.body)
         self.assertEqual(payload['error'].get('message'),
                          "session not found - 127.0.0.1:first_1")
-        
+
     def test_mixedcase_host(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/demo/first.commands'), self.stop)
+                                            '/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
-        self.assertEqual(response.code, 200)       
+        payload = json.loads(response.body)
+        self.assertEqual(response.code, 200)
 
         self.http_client.fetch(
-          self.get_url('/stubo/api/get/status?scenario=first',
-                       host='LOcalhost'), self.stop)                       
+            self.get_url('/stubo/api/get/status?scenario=first',
+                         host='LOcalhost'), self.stop)
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
-        self.assertEqual(response.code, 200)  
+        payload = json.loads(response.body)
+        self.assertEqual(response.code, 200)
         self.assertEqual(payload['data']['sessions'][0], ["first_1", "dormant"])
-        
+
         self.http_client.fetch(
-          self.get_url('/stubo/api/begin/session?scenario=first&session=first_1&mode=playback',
-                       host='LOcalhost'), self.stop)                       
+            self.get_url('/stubo/api/begin/session?scenario=first&session=first_1&mode=playback',
+                         host='LOcalhost'), self.stop)
         response = self.wait()
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
-        self.assertEqual(response.code, 200) 
-        
-        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1',  host='LOcalhost'), 
-            self.stop, method='POST', body="get my stub")                 
+        payload = json.loads(response.body)
+        self.assertEqual(response.code, 200)
+
+        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1', host='LOcalhost'),
+                               self.stop, method='POST', body="get my stub")
         response = self.wait()
-        self.assertEqual(response.code, 200)                
+        self.assertEqual(response.code, 200)
+
 
 class TestState(Base):
-    
     def test_state(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/state/converse.yaml'), self.stop)
+                                            '/static/cmds/tests/state/converse.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        stubo_responses = self.db.tracker.find({'function':'get/response'})
+        stubo_responses = self.db.tracker.find({'function': 'get/response'})
         sr = []
         for resp in stubo_responses:
             sr.append(resp['stubo_response'])
-        self.assertEqual(3,len(sr))
-        self.assertTrue('PNR 12345 with standard meal' in sr[0])
-        self.assertTrue('PNR 12345 has been updated (meal type change)' in sr[1])
-        self.assertTrue('PNR 12345 with veggy meal' in sr[2])
-        
-    def test_state_loop(self):
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/state/converse_loop.yaml'), self.stop)
-        response = self.wait()
-        self.assertEqual(response.code, 200)
-
-        stubo_responses = self.db.tracker.find({'function':'get/response'})
-        sr = []
-        for resp in stubo_responses:
-            sr.append(resp['stubo_response'])
-        self.assertEqual(6,len(sr))
-        self.assertTrue('PNR 12345 with standard meal' in sr[0])
-        self.assertTrue('PNR 12345 has been updated (meal type change)' \
-                        in sr[1])
-        self.assertTrue('PNR 12345 with veggy meal' in sr[2])
-        self.assertTrue('PNR 12345 with veggy meal' in sr[3])
-        self.assertTrue('PNR 12345 has been updated (meal type change)' \
-                        in sr[4])
-        self.assertTrue('PNR 12345 with veggy meal' in sr[5])     
-
-class TestTextState(Base):
-    
-    def test_state(self):
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/state/text/converse.commands'), self.stop)
-        response = self.wait()
-        self.assertEqual(response.code, 200)
-
-        stubo_responses = self.db.tracker.find({'function':'get/response'})
-        sr = []
-        for resp in stubo_responses:
-            sr.append(resp['stubo_response'])
-        self.assertEqual(3,len(sr))
+        self.assertEqual(3, len(sr))
         self.assertTrue('PNR 12345 with standard meal' in sr[0])
         self.assertTrue('PNR 12345 has been updated (meal type change)' in sr[1])
         self.assertTrue('PNR 12345 with veggy meal' in sr[2])
 
-
-    def test_state_reset(self):
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/state/text/converse_reset.commands'), self.stop)
-        response = self.wait()
-        self.assertEqual(response.code, 200)
-
-        stubo_responses = self.db.tracker.find({'function':'get/response'})
-        sr = []
-        for resp in stubo_responses:
-            sr.append(resp['stubo_response'])   
-        self.assertEqual(4,len(sr))
-        self.assertTrue('PNR 12345 with standard meal' in sr[0])
-        self.assertTrue('PNR 12345 with standard meal' in sr[1])
-        self.assertTrue('PNR 12345 has been updated (meal type change)' in sr[2])
-        self.assertTrue('PNR 12345 with veggy meal' in sr[3])
-    
     def test_state_loop(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/state/text/converse_loop.commands'), self.stop)
+                                            '/static/cmds/tests/state/converse_loop.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        stubo_responses = self.db.tracker.find({'function':'get/response'})
+        stubo_responses = self.db.tracker.find({'function': 'get/response'})
         sr = []
         for resp in stubo_responses:
             sr.append(resp['stubo_response'])
-        self.assertEqual(6,len(sr))
+        self.assertEqual(6, len(sr))
         self.assertTrue('PNR 12345 with standard meal' in sr[0])
         self.assertTrue('PNR 12345 has been updated (meal type change)' \
                         in sr[1])
@@ -919,18 +867,71 @@ class TestTextState(Base):
         self.assertTrue('PNR 12345 has been updated (meal type change)' \
                         in sr[4])
         self.assertTrue('PNR 12345 with veggy meal' in sr[5])
-    
-    def test_multi_state(self):
+
+
+class TestTextState(Base):
+    def test_state(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/state/text/converse_multi.commands'), self.stop)
+                                            '/static/cmds/tests/state/text/converse.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        stubo_responses = self.db.tracker.find({'function':'get/response'})
+        stubo_responses = self.db.tracker.find({'function': 'get/response'})
         sr = []
         for resp in stubo_responses:
             sr.append(resp['stubo_response'])
-        self.assertEqual(6,len(sr))
+        self.assertEqual(3, len(sr))
+        self.assertTrue('PNR 12345 with standard meal' in sr[0])
+        self.assertTrue('PNR 12345 has been updated (meal type change)' in sr[1])
+        self.assertTrue('PNR 12345 with veggy meal' in sr[2])
+
+    def test_state_reset(self):
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
+                                            '/static/cmds/tests/state/text/converse_reset.commands'), self.stop)
+        response = self.wait()
+        self.assertEqual(response.code, 200)
+
+        stubo_responses = self.db.tracker.find({'function': 'get/response'})
+        sr = []
+        for resp in stubo_responses:
+            sr.append(resp['stubo_response'])
+        self.assertEqual(4, len(sr))
+        self.assertTrue('PNR 12345 with standard meal' in sr[0])
+        self.assertTrue('PNR 12345 with standard meal' in sr[1])
+        self.assertTrue('PNR 12345 has been updated (meal type change)' in sr[2])
+        self.assertTrue('PNR 12345 with veggy meal' in sr[3])
+
+    def test_state_loop(self):
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
+                                            '/static/cmds/tests/state/text/converse_loop.commands'), self.stop)
+        response = self.wait()
+        self.assertEqual(response.code, 200)
+
+        stubo_responses = self.db.tracker.find({'function': 'get/response'})
+        sr = []
+        for resp in stubo_responses:
+            sr.append(resp['stubo_response'])
+        self.assertEqual(6, len(sr))
+        self.assertTrue('PNR 12345 with standard meal' in sr[0])
+        self.assertTrue('PNR 12345 has been updated (meal type change)' \
+                        in sr[1])
+        self.assertTrue('PNR 12345 with veggy meal' in sr[2])
+        self.assertTrue('PNR 12345 with veggy meal' in sr[3])
+        self.assertTrue('PNR 12345 has been updated (meal type change)' \
+                        in sr[4])
+        self.assertTrue('PNR 12345 with veggy meal' in sr[5])
+
+    def test_multi_state(self):
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
+                                            '/static/cmds/tests/state/text/converse_multi.commands'), self.stop)
+        response = self.wait()
+        self.assertEqual(response.code, 200)
+
+        stubo_responses = self.db.tracker.find({'function': 'get/response'})
+        sr = []
+        for resp in stubo_responses:
+            sr.append(resp['stubo_response'])
+        self.assertEqual(6, len(sr))
         self.assertTrue('PNR 12345 with standard meal' in sr[0])
         self.assertTrue('PNR 12345 has been updated (meal type change)' \
                         in sr[1])
@@ -941,60 +942,60 @@ class TestTextState(Base):
 
     def test_duplicate_stubs(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=record'), self.stop)
+                                            'first&session=first_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         self.http_client.fetch(self.get_url('/stubo/api/put/stub?session=first_1'), callback=self.stop,
-        method="POST", body="||textMatcher||abcdef||response||a response")
+                               method="POST", body="||textMatcher||abcdef||response||a response")
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         # insert a duplicate stub, which should not be loaded
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/stub?session=first_1'), callback=self.stop,
-        method="POST", body="||textMatcher||abcdef||response||a response")
+            method="POST", body="||textMatcher||abcdef||response||a response")
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         stubs = list(self.db.scenario_stub.find())
         self.assertTrue(len(stubs[0]['stub'].get('response')), 2)
-        
+
     def test_ignore_duplicate_stubs(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=record'), self.stop)
+                                            'first&session=first_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/stub?session=first_1&stateful=false'),
-                               callback=self.stop,
-        method="POST", body="||textMatcher||abcdef||response||a response")
+            callback=self.stop,
+            method="POST", body="||textMatcher||abcdef||response||a response")
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         # insert a duplicate stub, which should not be loaded
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/stub?session=first_1&stateful=false'),
-                               callback=self.stop,
-        method="POST", body="||textMatcher||abcdef||response||a response")
+            callback=self.stop,
+            method="POST", body="||textMatcher||abcdef||response||a response")
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         stubs = list(self.db.scenario_stub.find())
-        self.assertTrue(len(stubs[0]['stub'].get('response')), 1)  
+        self.assertTrue(len(stubs[0]['stub'].get('response')), 1)
 
-class TestSmartCommands(Base):  
 
+class TestSmartCommands(Base):
     def test_smart_commands(self):
         '''Demonstrate that command files can be Tornado templates with
            embedded code snippets. See the command file used in the next line.'''
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/accept/smart.commands'), self.stop)
+                                            '/static/cmds/tests/accept/smart.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        stubo_response = self.db.tracker.find_one({'function':'get/response'},
-            {'stubo_response':1})['stubo_response']
+        stubo_response = self.db.tracker.find_one({'function': 'get/response'},
+                                                  {'stubo_response': 1})['stubo_response']
         self.assertEqual('Hello 2 World', stubo_response)
 
         cmds = ['delete/stubs?scenario=smart',
@@ -1007,19 +1008,19 @@ class TestSmartCommands(Base):
         for cmd in cmds:
             self.assertTrue(cmd in response.body)
 
-        stubo_responses = self.db.tracker.find({'function':'get/response'})
+        stubo_responses = self.db.tracker.find({'function': 'get/response'})
         sr = []
         for resp in stubo_responses:
             sr.append(resp['stubo_response'])
-        self.assertEqual(3,len(sr))
+        self.assertEqual(3, len(sr))
         self.assertTrue('Hello' in sr[0])
         self.assertTrue('Hello' in sr[1])
         self.assertTrue('Hello' in sr[2])
-   
+
     def test_commands_with_foreign_urls(self):
         # Note that this only tests textMatcher and response files, not request files.
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-            '/static/cmds/tests/accept/foreign_url.commands'), self.stop)
+                                            '/static/cmds/tests/accept/foreign_url.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
@@ -1050,7 +1051,7 @@ class TestSmartCommands(Base):
         self.assertTrue(found_bbc)
 
         found_text = False
-        tracker_responses = self.db.tracker.find({'function':'get/response'})
+        tracker_responses = self.db.tracker.find({'function': 'get/response'})
         for response in tracker_responses:
             response_text = response['stubo_response']
             if 'response_text' in response_text:
@@ -1060,90 +1061,91 @@ class TestSmartCommands(Base):
     def test_smart_commands_with_params(self):
         '''send arguments into a command file for its use.'''
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/accept/smart_arg.commands&scen=bob&session='
-            'smart_1'), self.stop)
+                                            '/static/cmds/tests/accept/smart_arg.commands&scen=bob&session='
+                                            'smart_1'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        stubo_response = self.db.tracker.find_one({'function':'get/response'},
-            {'stubo_response':1})['stubo_response']
+        stubo_response = self.db.tracker.find_one({'function': 'get/response'},
+                                                  {'stubo_response': 1})['stubo_response']
         self.assertEqual('Hello 2 World', stubo_response)
 
+
 class TestYAMLImport(Base):
-    
     def _test_archive(self, archive):
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=' 
-            '/static/cmds/tests/rest/yaml/{0}'.format(archive)),
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
+                                            '/static/cmds/tests/rest/yaml/{0}'.format(archive)),
                                self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         response = json.loads(response.body)
         self.assertEqual(response['data']['number_of_errors'], 0)
         self.assertEqual(response['data']['number_of_requests'], 11)
-          
+
     def test_tar_gzip(self):
-        self._test_archive('yaml.tar.gz') 
-            
+        self._test_archive('yaml.tar.gz')
+
     def test_zip(self):
-        self._test_archive('yaml.zip') 
-        
+        self._test_archive('yaml.zip')
+
     def test_jar(self):
-        self._test_archive('yaml.zip')     
-            
+        self._test_archive('yaml.zip')
+
     def test_tar(self):
         self._test_archive('yaml.tar')
-        
+
     def test_zip_from_export(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/rest/yaml/1.yaml'), self.stop)
+                                            '/static/cmds/tests/rest/yaml/1.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/export?scenario=rest'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_rest/yaml_format/rest.zip'), self.stop)
+                                            '/static/exports/localhost_rest/yaml_format/rest.zip'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         response = json.loads(response.body)
         self.assertEqual(response['data']['number_of_errors'], 0)
         self.assertEqual(response['data']['number_of_requests'], 5)
-        
+
     def test_gzip_from_export(self):
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/tests/rest/yaml/1.yaml'), self.stop)
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/tests/rest/yaml/1.yaml'),
+                               self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/export?scenario=rest'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_rest/yaml_format/rest.tar.gz'), self.stop)
+                                            '/static/exports/localhost_rest/yaml_format/rest.tar.gz'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         response = json.loads(response.body)
         self.assertEqual(response['data']['number_of_errors'], 0)
-        self.assertEqual(response['data']['number_of_requests'], 5)     
-        
+        self.assertEqual(response['data']['number_of_requests'], 5)
+
     def test_post_exec_cmds(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_rest/yaml_format/rest.yaml'), callback=self.stop,
+                                            '/static/exports/localhost_rest/yaml_format/rest.yaml'), callback=self.stop,
                                method="POST", body="")
         response = self.wait()
-        self.assertEqual(response.code, 200)   
-    
+        self.assertEqual(response.code, 200)
+
+
 class TestCommandsImport(Base):
-    
     def _test_archive(self, archive):
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=' 
-            '/static/cmds/tests/exports/localhost_split/{0}'.format(archive)),
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
+                                            '/static/cmds/tests/exports/localhost_split/{0}'.format(archive)),
                                self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         cmds = [
             'put/module?name=/static/cmds/tests/ext/split/splitter.py',
             'delete/stubs?scenario=split&force=true',
@@ -1152,152 +1154,155 @@ class TestCommandsImport(Base):
             'end/session?session=split_1',
             'begin/session?scenario=split&session=split_1&mode=playback',
             'get/response?session=split_1&tracking_level=full,1.request',
-            'end/session?session=split_1'             
+            'end/session?session=split_1'
         ]
-            
+
         for cmd in cmds:
-            self.assertTrue(cmd in response.body)   
-          
+            self.assertTrue(cmd in response.body)
+
     def test_tar_gzip(self):
-        self._test_archive('split.tar.gz') 
-            
+        self._test_archive('split.tar.gz')
+
     def test_zip(self):
-        self._test_archive('split.zip') 
-            
+        self._test_archive('split.zip')
+
     def test_tar(self):
         self._test_archive('split.tar')
-                                 
+
     def test_zip_from_export(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/demo/first.commands'), self.stop)
+                                            '/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/export?scenario=first'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/yaml_format/first.zip'), self.stop)
+                                            '/static/exports/localhost_first/yaml_format/first.zip'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         cmds = ['delete/stubs?scenario=first',
                 'begin/session?scenario=first&session=first_1&mode=record',
                 'put/stub?session=first_1,first.textMatcher,first.response',
                 'end/session?session=first_1']
-        from urlparse import urlparse    
+        from urlparse import urlparse
+
         for cmd in cmds:
-            self.assertTrue(urlparse(cmd).path in response.body)  
-            
+            self.assertTrue(urlparse(cmd).path in response.body)
+
     def test_tar_gzip_from_export(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/demo/first.commands'), self.stop)
+                                            '/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/export?scenario=first'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/exports/localhost_first/yaml_format/first.tar.gz'), self.stop)
+                                            '/static/exports/localhost_first/yaml_format/first.tar.gz'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         cmds = ['delete/stubs?scenario=first',
                 'begin/session?scenario=first&session=first_1&mode=record',
                 'put/stub?session=first_1,first.textMatcher,first.response',
                 'end/session?session=first_1']
-        from urlparse import urlparse    
+        from urlparse import urlparse
+
         for cmd in cmds:
-            self.assertTrue(urlparse(cmd).path in response.body)   
-            
+            self.assertTrue(urlparse(cmd).path in response.body)
+
     def test_post_exec_cmds(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/demo/first.commands'), callback=self.stop, 
+                                            '/static/cmds/demo/first.commands'), callback=self.stop,
                                method="POST", body="")
         response = self.wait()
-        self.assertEqual(response.code, 200) 
-                        
+        self.assertEqual(response.code, 200)
+
+
 class TestSession(Base):
-    
     def test_duplicate(self):
         from stubo.model.db import Scenario
+
         scenario = Scenario()
         scenario.insert(name='localhost:first', status='dormant')
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-                               'first&session=first_1&mode=record'), self.stop)
+                                            'first&session=first_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 400)
-        
+
     def test_end_session(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=record'), self.stop)
+                                            'first&session=first_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/end/session?session='
-            'first_1'), self.stop)
+                                            'first_1'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
+        payload = json.loads(response.body)
         self.assertEqual(payload['data'], {"message": "Session ended"})
-        
+
     def test_end_sessions(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=record'), self.stop)
+                                            'first&session=first_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/end/sessions?scenario='
-            'first'), self.stop)
+                                            'first'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
-        self.assertEqual(payload['data'], 
-                         {u'first_1': {u'message': u'Session ended'}})  
-        
+        payload = json.loads(response.body)
+        self.assertEqual(payload['data'],
+                         {u'first_1': {u'message': u'Session ended'}})
+
     def test_end_sessions2(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=record'), self.stop)
+                                            'first&session=first_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/stub?session=first_1'), callback=self.stop,
             method="POST", body="||textMatcher||abcdef||response||a response")
         response = self.wait()
-        
+        self.assertEqual(response.code, 200)
+
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/end/session?session=first_1'),
-                               self.stop)
+            '/stubo/api/end/session?session=first_1'),
+            self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=playback'), self.stop)
+                                            'first&session=first_1&mode=playback'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_2&mode=playback'), self.stop)
+                                            'first&session=first_2&mode=playback'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/end/sessions?scenario='
-            'first'), self.stop)
+                                            'first'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
-        self.assertEqual(payload['data'], 
+        payload = json.loads(response.body)
+        self.assertEqual(payload['data'],
                          {u'first_1': {u'message': u'Session ended'},
-                          u'first_2': {u'message': u'Session ended'}})      
-                  
-        
-    def test_warm_cache(self):     
+                          u'first_2': {u'message': u'Session ended'}})
+
+    def test_warm_cache(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=record'), self.stop)
+                                            'first&session=first_1&mode=record'), self.stop)
         response = self.wait()
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/stub?session=first_1'), callback=self.stop,
@@ -1307,16 +1312,17 @@ class TestSession(Base):
             '/stubo/api/end/session?session=first_1'), callback=self.stop)
         response = self.wait()
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=playback&warm_cache=true'),
+                                            'first&session=first_1&mode=playback&warm_cache=true'),
                                callback=self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         from stubo.cache import key_exists
+
         self.assertTrue(key_exists('localhost:first:request'))
-        
-    def test_stateful_warm_cache(self):     
+
+    def test_stateful_warm_cache(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=record'), self.stop)
+                                            'first&session=first_1&mode=record'), self.stop)
         response = self.wait()
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/stub?session=first_1'), callback=self.stop,
@@ -1330,25 +1336,27 @@ class TestSession(Base):
             '/stubo/api/end/session?session=first_1'), callback=self.stop)
         response = self.wait()
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'first&session=first_1&mode=playback&warm_cache=true'),
+                                            'first&session=first_1&mode=playback&warm_cache=true'),
                                callback=self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         from stubo.cache import key_exists
-        self.assertTrue(key_exists('localhost:first:request')) 
-        self.assertTrue(key_exists('localhost:first:request_index'))   
-        
+
+        self.assertTrue(key_exists('localhost:first:request'))
+        self.assertTrue(key_exists('localhost:first:request_index'))
+
     def test_session_already_ended(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/end/session?scenario=first&session=first_1'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        self.assertEqual(response.headers["Content-Type"], 
+        self.assertEqual(response.headers["Content-Type"],
                          'application/json; charset=UTF-8')
-        payload = json.loads(response.body) 
-        self.assertEqual(response.code, 200)       
+        payload = json.loads(response.body)
+        self.assertEqual(response.code, 200)
         self.assertEqual(payload['data']['message'], 'Session ended')
-        
+
+
 """ requires graphite stats server
 class TestStats(Base):
     
@@ -1359,25 +1367,29 @@ class TestStats(Base):
         payload = json.loads(response.body) 
         self.assertEqual(payload.get('data'),
           {"metric": "latency", "percent_above_value": 50, 
-           "target": "averageSeries(stats.timers.stubo.aws_cluster1.ba-perf-vip1.*.stuboapi.get_response.latency.mean_90)", 
+           "target":
+           "averageSeries(stats.timers.stubo.aws_cluster1.ba-perf-vip1.*.stuboapi.get_response.latency.mean_90)",
            "pcent": 0.0,
            "from" : "-1mins",
            "to" : "now"})
         
     def test_higher_than_1sec(self):
-        self.http_client.fetch(self.get_url('/stubo/api/get/stats?cluster=aws_cluster1&from=-1mins&percent_above_value=1000'), self.stop)
+        self.http_client.fetch(
+        self.get_url('/stubo/api/get/stats?cluster=aws_cluster1&from=-1mins&percent_above_value=1000'), self.stop)
         response = self.wait()
         self.assertTrue('application/json' in response.headers.get("Content-Type")) 
         payload = json.loads(response.body) 
         self.assertEqual(payload.get('data'),
           {"metric": "latency", "percent_above_value": 1000, 
-           "target": "averageSeries(stats.timers.stubo.aws_cluster1.ba-perf-vip1.*.stuboapi.get_response.latency.mean_90)", 
+           "target":
+           "averageSeries(stats.timers.stubo.aws_cluster1.ba-perf-vip1.*.stuboapi.get_response.latency.mean_90)",
            "pcent": 0.0,
            "from" : "-1mins",
            "to" : "now"})
         
     def test_unknown_cluster(self):
-        self.http_client.fetch(self.get_url('/stubo/api/get/stats?cluster=bogus&from=-1mins&percent_above_value=1000'), self.stop)
+        self.http_client.fetch(self.get_url(
+        '/stubo/api/get/stats?cluster=bogus&from=-1mins&percent_above_value=1000'), self.stop)
         response = self.wait()
         self.assertTrue('application/json' in response.headers.get("Content-Type"))
         payload = json.loads(response.body) 
@@ -1391,139 +1403,140 @@ class TestStats(Base):
         self.assertEqual(payload['error']['code'], 500)  
         
     def test_bad_arg(self):
-        self.http_client.fetch(self.get_url('/stubo/api/get/stats?cluster=aws_cluster1&from=-1mins&metric=bogus'), self.stop)
+        self.http_client.fetch(
+        self.get_url('/stubo/api/get/stats?cluster=aws_cluster1&from=-1mins&metric=bogus'), self.stop)
         response = self.wait()
         self.assertTrue('application/json' in response.headers["Content-Type"])
         payload = json.loads(response.body) 
         self.assertEqual(payload['error']['code'], 400) 
 """
-        
-class TestTracker(Base):  
 
+
+class TestTracker(Base):
     def test_response_size(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/delay_policy?name=foo'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'get/delay_policy'})
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'get/delay_policy'})
         self.assertEqual(int(response.headers['Content-Length']),
                          tracker['response_size'])
-        
+
     def test_request_param(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/delay_policy?name=foo'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'get/delay_policy'})
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'get/delay_policy'})
         self.assertTrue('request_params' in tracker)
-        self.assertEqual(tracker['request_params'].get('name'), 'foo') 
-        
+        self.assertEqual(tracker['request_params'].get('name'), 'foo')
+
     def test_request_header(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/delay_policy?name=foo'), self.stop,
-                               headers={'Foo' : 'bar'})
+            headers={'Foo': 'bar'})
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'get/delay_policy'})
-        self.assertTrue('request_headers' in tracker)  
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'get/delay_policy'})
+        self.assertTrue('request_headers' in tracker)
         self.assertEqual(tracker['request_headers'].get('Foo'), 'bar')
-        
+
     def test_request_param_multiple_values(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/delay_policy?name=foo&name=bar'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'get/delay_policy'})
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'get/delay_policy'})
         self.assertTrue('request_params' in tracker)
-        self.assertEqual(tracker['request_params'].get('name'), ['foo', 'bar']) 
-        
+        self.assertEqual(tracker['request_params'].get('name'), ['foo', 'bar'])
+
     def test_request_param_multiple_values2(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/delay_policy?name=foo&another_key=bar'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'get/delay_policy'})
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'get/delay_policy'})
         self.assertTrue('request_params' in tracker)
-        self.assertEqual(tracker['request_params'].get('name'), 'foo') 
+        self.assertEqual(tracker['request_params'].get('name'), 'foo')
         self.assertEqual(tracker['request_params'].get('another_key'), 'bar')
-        
+
     def test_request_param_skip_dotted_name(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/delay_policy?name=foo&bar.1=xxx'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'get/delay_policy'})
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'get/delay_policy'})
         self.assertTrue('request_params' in tracker)
-        self.assertEqual(tracker['request_params'].get('bar.1'), None) 
-        self.assertEqual(tracker['request_params'].get('name'), 'foo') 
-        
+        self.assertEqual(tracker['request_params'].get('bar.1'), None)
+        self.assertEqual(tracker['request_params'].get('name'), 'foo')
+
     def test_request_param_skip_dotted_name_in_headers(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/delay_policy?name=foo&bar.1=xxx'), self.stop,
-                               headers={'bar.1' : 'hello'})
+            headers={'bar.1': 'hello'})
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'get/delay_policy'})
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'get/delay_policy'})
         self.assertTrue('request_params' in tracker)
-        self.assertEqual(tracker['request_params'].get('bar.1'), None) 
-        self.assertEqual(tracker['request_params'].get('name'), 'foo') 
-        
+        self.assertEqual(tracker['request_params'].get('bar.1'), None)
+        self.assertEqual(tracker['request_params'].get('name'), 'foo')
+
     def test_request_session_param_in_headers(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
+                                            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
-        self.http_client.fetch(self.get_url('/stubo/api/get/response'), 
-            self.stop, method='POST', body="get my stub", 
-            headers={'Stubo-Request-Session' : 'first_1'})                 
+        self.assertEqual(response.code, 200)
+        self.http_client.fetch(self.get_url('/stubo/api/get/response'),
+                               self.stop, method='POST', body="get my stub",
+                               headers={'Stubo-Request-Session': 'first_1'})
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'get/response'})
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'get/response'})
         self.assertEqual(tracker['request_headers'].get(
-            'Stubo-Request-Session'), 'first_1') 
-        
+            'Stubo-Request-Session'), 'first_1')
+
     def test_request_session_legacy_param_in_headers(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
+                                            '/static/cmds/tests/accept/first_setup.commands'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
-        self.http_client.fetch(self.get_url('/stubo/api/get/response'), 
-            self.stop, method='POST', body="get my stub", 
-            headers={'stb_session' : '1', 'stb_scenario' : 'first'})                 
+        self.assertEqual(response.code, 200)
+        self.http_client.fetch(self.get_url('/stubo/api/get/response'),
+                               self.stop, method='POST', body="get my stub",
+                               headers={'stb_session': '1', 'stb_scenario': 'first'})
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'get/response'})
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'get/response'})
         self.assertEqual(tracker['request_headers'].get(
-            'Stubo-Request-Session'), 'first_1')     
-                    
+            'Stubo-Request-Session'), 'first_1')
+
     def test_stubo_response_is_trimmed(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/exec/cmds?cmdFile=/static/cmds/demo/first.commands'),
-                               self.stop)
+            self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
-        tracker = self.db.tracker.find_one({'function':'exec/cmds'})
-        self.assertEqual(int(response.headers['Content-Length']), tracker['response_size']) 
-        self.assertTrue(int(response.headers['Content-Length']) > len(tracker['stubo_response']))         
-        
+        self.assertEqual(response.code, 200)
+        tracker = self.db.tracker.find_one({'function': 'exec/cmds'})
+        self.assertEqual(int(response.headers['Content-Length']), tracker['response_size'])
+        self.assertTrue(int(response.headers['Content-Length']) > len(tracker['stubo_response']))
+
     def test_minimal_tracking_level(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-            '/static/cmds/tests/accept/minimal_logging.commands'), self.stop)
+                                            '/static/cmds/tests/accept/minimal_logging.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        tracker = self.db.tracker.find_one({'function':'get/response'})
+        tracker = self.db.tracker.find_one({'function': 'get/response'})
         # minimal or full tracking level items
         self.assertEqual(tracker['function'], "get/response")
-        self.assertTrue(tracker['start_time'] != None)
+        self.assertTrue(tracker['start_time'] is not None)
         self.assertEqual(tracker['return_code'], 200)
-        self.assertTrue(tracker['server'] != None)
-        self.assertTrue(tracker['host'] != None)
+        self.assertTrue(tracker['server'] is not None)
+        self.assertTrue(tracker['host'] is not None)
         self.assertEqual(tracker['request_params']['session'], "first_1")
         self.assertEqual(tracker['scenario'], "first")
-        self.assertTrue(tracker['duration_ms'] != None)
-        self.assertTrue(tracker['remote_ip'] != None)
-        self.assertTrue(tracker['delay'] != None)
+        self.assertTrue(tracker['duration_ms'] is not None)
+        self.assertTrue(tracker['remote_ip'] is not None)
+        self.assertTrue(tracker['delay'] is not None)
         self.assertEqual(tracker['stubo_response'], "Hello 2 World")
 
         # not for minimal tracking as these can be big.
@@ -1534,11 +1547,11 @@ class TestTracker(Base):
 
     def test_full_tracking_level(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdFile='
-            '/static/cmds/tests/accept/full_logging.commands'), self.stop)
+                                            '/static/cmds/tests/accept/full_logging.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        tracker = self.db.tracker.find_one({'function':'get/response'})
+        tracker = self.db.tracker.find_one({'function': 'get/response'})
         # minimal or full tracking level items
         self.assertEqual(tracker['function'], "get/response")
         self.assertTrue(tracker['start_time'] is not None)
@@ -1557,21 +1570,21 @@ class TestTracker(Base):
         self.assertEqual(tracker['request_text'],
                          'timestamp: 09:23:45\nget my stubs\n')
         self.assertTrue('trace' in tracker)
-            
-class TestSetting(Base):  
 
+
+class TestSetting(Base):
     def test_set(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=foo&value=bar'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('data'), {
-            "new": "true", "host": "localhost", "all" : False, "foo": "bar"
-        }) 
-        
+            "new": "true", "host": "localhost", "all": False, "foo": "bar"
+        })
+
     def test_modify(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=foo&value=bar'), self.stop)
@@ -1579,499 +1592,504 @@ class TestSetting(Base):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=foo&value=bar2'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.assertTrue('application/json' in response.headers.get("Content-Type"))
-        payload = json.loads(response.body) 
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('data'), {
-            "new": "false", "host": "localhost", "all" : False, "foo": "bar2"
-        })   
-        
+            "new": "false", "host": "localhost", "all": False, "foo": "bar2"
+        })
+
     def test_get(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=foo&value=bar'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/setting?setting=foo'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)  
+        self.assertEqual(response.code, 200)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('data'), {
-            "host": "localhost", "all" : False, "foo": "bar"
-        })  
-        
+            "host": "localhost", "all": False, "foo": "bar"
+        })
+
     def test_get_all(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=foo&value=bar'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=foo2&value=bar2'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
-        
+        self.assertEqual(response.code, 200)
+
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/setting?'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)  
+        self.assertEqual(response.code, 200)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('data'), {
-            "host": "localhost", "all" : False, 
-            "settings" : {"foo": "bar", "foo2": "bar2"}
-        })      
-        
+            "host": "localhost", "all": False,
+            "settings": {"foo": "bar", "foo2": "bar2"}
+        })
+
     def test_empty_get(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/setting?setting=foo'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)  
+        self.assertEqual(response.code, 200)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('data'), {
-            "host": "localhost", "all" : False, "foo": None
-        })  
-        
+            "host": "localhost", "all": False, "foo": None
+        })
+
     def test_global_set(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?host=all&setting=foo&value=bar'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('data'), {
-            "new": "true", "host": "localhost", "all" : True, "foo": "bar"
-        }) 
-        
+            "new": "true", "host": "localhost", "all": True, "foo": "bar"
+        })
+
     def test_global_modify(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?host=all&setting=foo&value=bar'), self.stop)
         response = self.wait()
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?host=all&setting=foo&value=bar2'),
-                               self.stop)
+            self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('data'), {
-            "new": "false", "host": "localhost", "all" : True, "foo": "bar2"
-        })   
-        
+            "new": "false", "host": "localhost", "all": True, "foo": "bar2"
+        })
+
     def test_global_get(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?host=all&setting=foo&value=bar'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/setting?host=all&setting=foo'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)  
+        self.assertEqual(response.code, 200)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('data'), {
-            "host": "localhost", "all" : True, "foo": "bar"
-        })  
-        
+            "host": "localhost", "all": True, "foo": "bar"
+        })
+
     def test_global_empty_get(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/get/setting?host=all&setting=foo'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)  
+        self.assertEqual(response.code, 200)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('data'), {
-            "host": "localhost", "all" : True, "foo": None
-        }) 
-        
-    
+            "host": "localhost", "all": True, "foo": None
+        })
+
     def test_blacklisted(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=blacklisted&value=true'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/begin/session?scenario=foo&session=foo_1&mode=record'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 400)   
+        self.assertEqual(response.code, 400)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('error'), {
-            'code': 400,                                    
+            'code': 400,
             'message': "Sorry the host URL 'localhost' has been blacklisted. Please contact Stub-O-Matic support."
-        }) 
-        
+        })
+
     def test_blacklisted2(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=blacklisted&value=1'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/begin/session?scenario=foo&session=foo_1&mode=record'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 400)   
+        self.assertEqual(response.code, 400)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('error'), {
-            'code': 400,                                    
+            'code': 400,
             'message': "Sorry the host URL 'localhost' has been blacklisted. Please contact Stub-O-Matic support."
-        })   
-        
+        })
+
     def test_blacklisted3(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=blacklisted&value=True'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/begin/session?scenario=foo&session=foo_1&mode=record'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 400)   
+        self.assertEqual(response.code, 400)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('error'), {
-            'code': 400,                                    
+            'code': 400,
             'message': "Sorry the host URL 'localhost' has been blacklisted. Please contact Stub-O-Matic support."
-        })          
-        
+        })
+
     def test_blacklisted_off(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=blacklisted&value=true'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/begin/session?scenario=foo&session=foo_1&mode=record'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 400)   
+        self.assertEqual(response.code, 400)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('error'), {
-            'code': 400,                                    
+            'code': 400,
             'message': "Sorry the host URL 'localhost' has been blacklisted. Please contact Stub-O-Matic support."
-        }) 
-        
+        })
+
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=blacklisted&value=false'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
             '/stubo/api/begin/session?scenario=foo&session=foo_1&mode=record'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)      
-        
+        self.assertEqual(response.code, 200)
+
     def test_blacklisted_on_get_response(self):
         self.http_client.fetch(self.get_url(
             '/stubo/api/put/setting?setting=blacklisted&value=true'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)              
+        self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url(
-                               '/stubo/api/get/response?session=foo'),
-                               callback=self.stop, method="POST",
-                               body="get my stub")
+            '/stubo/api/get/response?session=foo'),
+            callback=self.stop, method="POST",
+            body="get my stub")
         response = self.wait()
-        self.assertEqual(response.code, 400)   
+        self.assertEqual(response.code, 400)
         self.assertTrue('application/json' in response.headers.get(
-                        "Content-Type"))
-        payload = json.loads(response.body) 
+            "Content-Type"))
+        payload = json.loads(response.body)
         self.assertEqual(payload.get('error'), {
-            'code': 400,                                    
+            'code': 400,
             'message': "Sorry the host URL 'localhost' has been blacklisted. Please contact Stub-O-Matic support."
-        })                               
-             
-class TestTextTemplates(Base):  
+        })
 
+
+class TestTextTemplates(Base):
     def test_matcher(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/templates/matcher/text/all.commands'), self.stop)
+                                            '/static/cmds/tests/templates/matcher/text/all.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        result = list(self.db.tracker.find({'function':'get/response'}))
+        result = list(self.db.tracker.find({'function': 'get/response'}))
         self.assertEqual(1, len(result))
         response = result[0]['stubo_response']
         self.assertEqual(response, '<response>you found me</response>')
-      
-        
+
     def test_dateroll_args(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/templates/dateroll/text/first.commands'), self.stop)
+                                            '/static/cmds/tests/templates/dateroll/text/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        result = list(self.db.tracker.find({'function':'get/response'}))
+        result = list(self.db.tracker.find({'function': 'get/response'}))
         self.assertEqual(1, len(result))
         response = result[0]['stubo_response']
         import datetime
+
         d = datetime.date.today()
         self.assertTrue('<putstub_arg>this stub was recorded at {0}'.format(
-                        d) in response)
+            d) in response)
         self.assertTrue('<getresponse_arg>this stub was played at {0}'.format(
-                        d+datetime.timedelta(1)) in response)
-        
-class TestTemplates(Base):  
+            d + datetime.timedelta(1)) in response)
 
+
+class TestTemplates(Base):
     def test_matcher(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/templates/matcher/matcher.yaml'), self.stop)
+                                            '/static/cmds/tests/templates/matcher/matcher.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        result = list(self.db.tracker.find({'function':'get/response'}))
+        result = list(self.db.tracker.find({'function': 'get/response'}))
         self.assertEqual(1, len(result))
         response = result[0]['stubo_response']
         self.assertEqual(response, '<response>you found me</response>')
-      
-        
+
     def test_dateroll_args(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/templates/dateroll/dateroll.yaml'), self.stop)
+                                            '/static/cmds/tests/templates/dateroll/dateroll.yaml'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
-        result = list(self.db.tracker.find({'function':'get/response'}))
+        result = list(self.db.tracker.find({'function': 'get/response'}))
         self.assertEqual(1, len(result))
         response = result[0]['stubo_response']
         import datetime
+
         d = datetime.date.today()
         self.assertTrue('<putstub_arg>this stub was recorded at {0}'.format(
-                        d) in response)
+            d) in response)
         self.assertTrue('<getresponse_arg>this stub was played at {0}'.format(
-                        d++datetime.timedelta(1)) in response)        
-       
-class TestGetScenarios(Base):       
-    
+            d + +datetime.timedelta(1)) in response)
+
+
+class TestGetScenarios(Base):
     def test_empty(self):
         self.http_client.fetch(self.get_url('/stubo/api/get/scenarios'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertEqual(payload.get('data'), 
+        self.assertEqual(payload.get('data'),
                          {"scenarios": [], "host": "localhost"})
-        
+
     def test_host(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(self.get_url('/stubo/api/get/scenarios'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertEqual(payload.get('data'), 
-                         {"scenarios": ["localhost:first"], "host": "localhost"}) 
-        
+        self.assertEqual(payload.get('data'),
+                         {"scenarios": ["localhost:first"], "host": "localhost"})
+
         self.http_client.fetch(self.get_url('/stubo/api/get/scenarios?host=localhost'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertEqual(payload.get('data'), 
-                         {"scenarios": ["localhost:first"], "host": "localhost"}) 
-        
+        self.assertEqual(payload.get('data'),
+                         {"scenarios": ["localhost:first"], "host": "localhost"})
+
     def test_all_hosts(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile='
-            '/static/cmds/tests/state/text/converse.commands'), self.stop)
+                                            '/static/cmds/tests/state/text/converse.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(self.get_url('/stubo/api/get/scenarios'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertEqual(payload.get('data'), 
-            {"scenarios": ["localhost:first", "localhost:converse"], 
-             "host": "localhost"})       
-        
+        self.assertEqual(payload.get('data'),
+                         {"scenarios": ["localhost:first", "localhost:converse"],
+                          "host": "localhost"})
+
     def test_other_host(self):
         self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first.commands'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(self.get_url('/stubo/api/get/scenarios?host=bogus'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         payload = json.loads(response.body)
-        self.assertEqual(payload.get('data'), 
-                         {"scenarios": [], "host": "bogus"}) 
-        
-             
+        self.assertEqual(payload.get('data'),
+                         {"scenarios": [], "host": "bogus"})
+
+
 class TestGetResponse(Base):
-    
     def test_mode_in_playback(self):
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'), self.stop)
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'),
+                               self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/end/session?session=first_1'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
-        
+        self.assertEqual(response.code, 200)
+
         self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1'), self.stop,
-                                method="POST", body="timestamp: 09:23:45 get my stub")
+                               method="POST", body="timestamp: 09:23:45 get my stub")
         response = self.wait()
-        self.assertEqual(response.code, 500) 
-        payload = json.loads(response.body)    
+        self.assertEqual(response.code, 500)
+        payload = json.loads(response.body)
         self.assertTrue(payload['error']['message'].startswith("cache status != playback"))
-        
+
     def test_get_response_url_session_arg_is_used(self):
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'), self.stop)
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'),
+                               self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.http_client.fetch(self.get_url('/stubo/api/end/session?session=first_1'), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
-        
-        self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario=first&session=playme&mode=playback'), self.stop)
+        self.assertEqual(response.code, 200)
+
+        self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario=first&session=playme&mode=playback'),
+                               self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200) 
-        
+        self.assertEqual(response.code, 200)
+
         self.http_client.fetch(self.get_url('/stubo/api/get/response?session=playme'), self.stop,
-                                method="POST", body="timestamp: 09:23:45 get my stub")
+                               method="POST", body="timestamp: 09:23:45 get my stub")
         response = self.wait()
-        self.assertEqual(response.code, 200) 
-        
-        tracker = self.db.tracker.find_one({'function':'get/response'})
+        self.assertEqual(response.code, 200)
+
+        tracker = self.db.tracker.find_one({'function': 'get/response'})
         self.assertEqual(tracker['request_params'].get('session'), 'playme')
-                  
-class TestHTTPCompression(Base):    
-     
+
+
+class TestHTTPCompression(Base):
     def get_httpserver_options(self):
-        return dict(decompress_request=True)   
-   
-    def test_gzip_request(self):  
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'), self.stop)
+        return dict(decompress_request=True)
+
+    def test_gzip_request(self):
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'),
+                               self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
         import StringIO, gzip
+
         stringio = StringIO.StringIO()
         gzip_file = gzip.GzipFile(fileobj=stringio, mode='w')
         gzip_file.write("get my stub")
         gzip_file.close()
-     
-        response =  self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1'),  
-                                           self.stop, 
-                                           use_gzip=False,
-                                           headers={"Content-Encoding": "gzip",
-                                                    "Accept-Encoding": "gzip"},
-                                           method="POST", 
-                                           body=stringio.getvalue())
+
+        response = self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1'),
+                                          self.stop,
+                                          use_gzip=False,
+                                          headers={"Content-Encoding": "gzip",
+                                                   "Accept-Encoding": "gzip"},
+                                          method="POST",
+                                          body=stringio.getvalue())
         response = self.wait()
         self.assertEqual(response.code, 200)
-        self.assertEqual(response.body[:-1], b"Hello 2 World")   
-        
+        self.assertEqual(response.body[:-1], b"Hello 2 World")
+
     def test_gzip_response_is_disabled(self):
-         
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'), self.stop)
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'),
+                               self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
-        response =  self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1'),  self.stop, 
-                                           use_gzip=False,
-                                           headers={"Accept-Encoding": "gzip"},
-                                           method="POST", body="get my stub")
+
+        response = self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1'), self.stop,
+                                          use_gzip=False,
+                                          headers={"Accept-Encoding": "gzip"},
+                                          method="POST", body="get my stub")
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.assertNotEqual(response.headers.get("Content-Encoding"), "gzip")
-        self.assertEqual(response.body[:-1], b"Hello 2 World")     
-      
+        self.assertEqual(response.body[:-1], b"Hello 2 World")
+
+
 class TestHTTPResponseCompressionEnabled(Base):
-        
-    def get_app(self):    
-          self.cfg['compress_response'] = True
-          return super(TestHTTPResponseCompressionEnabled, self).get_app()
-                
+    def get_app(self):
+        self.cfg['compress_response'] = True
+        return super(TestHTTPResponseCompressionEnabled, self).get_app()
+
     def test_gzip_response(self):
-         
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'), self.stop)
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'),
+                               self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        response =  self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1'),  self.stop, 
-                                           use_gzip=False,
-                                           headers={"Accept-Encoding": "gzip"},
-                                           method="POST", body="get my stub")
+        response = self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1'), self.stop,
+                                          use_gzip=False,
+                                          headers={"Accept-Encoding": "gzip"},
+                                          method="POST", body="get my stub")
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.assertEqual(response.headers.get("Content-Encoding"), "gzip")
         # Our test data gets bigger when gzipped.  Oops.  :)
         self.assertEqual(len(response.body), 34)
         import gzip
+
         f = gzip.GzipFile(mode="r", fileobj=response.buffer)
         self.assertEqual(f.read()[:-1], b"Hello 2 World")
-        
+
     def test_gzip_response_not_desired(self):
-         
-        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'), self.stop)
+        self.http_client.fetch(self.get_url('/stubo/api/exec/cmds?cmdfile=/static/cmds/demo/first_setup.commands'),
+                               self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-         
-        response =  self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1'),  self.stop, 
-                                           use_gzip=False,
-                                           headers={"Accept-Encoding": "identity"},
-                                           method="POST", body="get my stub")
+
+        response = self.http_client.fetch(self.get_url('/stubo/api/get/response?session=first_1'), self.stop,
+                                          use_gzip=False,
+                                          headers={"Accept-Encoding": "identity"},
+                                          method="POST", body="get my stub")
         response = self.wait()
         self.assertEqual(response.code, 200)
         self.assertNotEqual(response.headers.get("Content-Encoding"), "gzip")
-        self.assertEqual(response.body[:-1], b"Hello 2 World")    
-       
+        self.assertEqual(response.body[:-1], b"Hello 2 World")
+
+
 class TestRest(Base):
-    
     def test_error_response(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'rest&session=rest_1&mode=record'), self.stop)
+                                            'rest&session=rest_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
         stub = {
             "request": {
                 "method": "POST",
-                "bodyPatterns": 
-                    { "contains": ["<status>OK</status>"] }
-                },
+                "bodyPatterns":
+                    {"contains": ["<status>OK</status>"]}
+            },
             "response": {
                 "status": 400,
                 "body": "<response>YES</response>"
             }
         }
         import json
+
         self.http_client.fetch(self.get_url('/stubo/api/put/stub?session=rest_1'), callback=self.stop,
-        method="POST", body=json.dumps(stub),  headers={'Content-Type' : 'application/json'})
+                               method="POST", body=json.dumps(stub), headers={'Content-Type': 'application/json'})
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         stubs = list(self.db.scenario_stub.find())
-        self.assertEqual(len(stubs), 1)  
-        
+        self.assertEqual(len(stubs), 1)
+
         self.http_client.fetch(
-          self.get_url('/stubo/api/end/session?session=rest_1'), self.stop)                       
+            self.get_url('/stubo/api/end/session?session=rest_1'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(
-          self.get_url('/stubo/api/begin/session?scenario=rest&session=rest_1&mode=playback'), self.stop)                       
+            self.get_url('/stubo/api/begin/session?scenario=rest&session=rest_1&mode=playback'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
-        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=rest_1'), 
-            self.stop, method='POST', body="<status>OK</status>")                 
+
+        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=rest_1'),
+                               self.stop, method='POST', body="<status>OK</status>")
         response = self.wait()
-        self.assertEqual(response.code, 400)  
-        
+        self.assertEqual(response.code, 400)
+
     def test_empty_response(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'rest&session=rest_1&mode=record'), self.stop)
+                                            'rest&session=rest_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
@@ -2079,40 +2097,41 @@ class TestRest(Base):
             "request": {
                 "method": "DELETE",
                 "urlPath": "/some/content"
-                },
+            },
             "response": {
                 "status": 204,
-                "body" : "",
+                "body": "",
             }
         }
         import json
+
         self.http_client.fetch(self.get_url('/stubo/api/put/stub?session=rest_1'), callback=self.stop,
-        method="POST", body=json.dumps(stub),  headers={'Content-Type' : 'application/json'})
+                               method="POST", body=json.dumps(stub), headers={'Content-Type': 'application/json'})
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         stubs = list(self.db.scenario_stub.find())
-        self.assertEqual(len(stubs), 1)  
-        
+        self.assertEqual(len(stubs), 1)
+
         self.http_client.fetch(
-          self.get_url('/stubo/api/end/session?session=rest_1'), self.stop)                       
+            self.get_url('/stubo/api/end/session?session=rest_1'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(
-          self.get_url('/stubo/api/begin/session?scenario=rest&session=rest_1&mode=playback'), self.stop)                       
+            self.get_url('/stubo/api/begin/session?scenario=rest&session=rest_1&mode=playback'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
-        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=rest_1'), 
-            self.stop, method='POST', body="", headers={'Stubo-Request-Path' : '/some/content',
-                                               'Stubo-Request-Method': 'DELETE'})                 
+
+        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=rest_1'),
+                               self.stop, method='POST', body="", headers={'Stubo-Request-Path': '/some/content',
+                                                                           'Stubo-Request-Method': 'DELETE'})
         response = self.wait()
-        self.assertEqual(response.code, 204)    
-        
+        self.assertEqual(response.code, 204)
+
     def test_empty_response2(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'rest&session=rest_1&mode=record'), self.stop)
+                                            'rest&session=rest_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
@@ -2120,39 +2139,40 @@ class TestRest(Base):
             "request": {
                 "method": "DELETE",
                 "urlPath": "/some/content"
-                },
+            },
             "response": {
                 "status": 204,
             }
         }
         import json
+
         self.http_client.fetch(self.get_url('/stubo/api/put/stub?session=rest_1'), callback=self.stop,
-        method="POST", body=json.dumps(stub),  headers={'Content-Type' : 'application/json'})
+                               method="POST", body=json.dumps(stub), headers={'Content-Type': 'application/json'})
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         stubs = list(self.db.scenario_stub.find())
-        self.assertEqual(len(stubs), 1)  
-        
+        self.assertEqual(len(stubs), 1)
+
         self.http_client.fetch(
-          self.get_url('/stubo/api/end/session?session=rest_1'), self.stop)                       
+            self.get_url('/stubo/api/end/session?session=rest_1'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(
-          self.get_url('/stubo/api/begin/session?scenario=rest&session=rest_1&mode=playback'), self.stop)                       
+            self.get_url('/stubo/api/begin/session?scenario=rest&session=rest_1&mode=playback'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
-        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=rest_1'), 
-            self.stop, method='POST', body="", headers={'Stubo-Request-Path' : '/some/content',
-                                               'Stubo-Request-Method': 'DELETE'})                 
+
+        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=rest_1'),
+                               self.stop, method='POST', body="", headers={'Stubo-Request-Path': '/some/content',
+                                                                           'Stubo-Request-Method': 'DELETE'})
         response = self.wait()
-        self.assertEqual(response.code, 204)   
-        
+        self.assertEqual(response.code, 204)
+
     def test_response_headers(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
-            'rest&session=rest_1&mode=record'), self.stop)
+                                            'rest&session=rest_1&mode=record'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
 
@@ -2160,39 +2180,40 @@ class TestRest(Base):
             "request": {
                 "method": "GET",
                 "urlPath": "/some/content"
-                },
+            },
             "response": {
                 "status": 200,
-                "body": {"x" : "y"},
+                "body": {"x": "y"},
                 "headers": {
-                   "Content-Type": "application/json",
-                   "My-App" : "XYZ"         
+                    "Content-Type": "application/json",
+                    "My-App": "XYZ"
                 }
             }
         }
         import json
+
         self.http_client.fetch(self.get_url('/stubo/api/put/stub?session=rest_1'), callback=self.stop,
-        method="POST", body=json.dumps(stub),  headers={'Content-Type' : 'application/json'})
+                               method="POST", body=json.dumps(stub), headers={'Content-Type': 'application/json'})
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         stubs = list(self.db.scenario_stub.find())
-        self.assertEqual(len(stubs), 1)  
-        
+        self.assertEqual(len(stubs), 1)
+
         self.http_client.fetch(
-          self.get_url('/stubo/api/end/session?session=rest_1'), self.stop)                       
+            self.get_url('/stubo/api/end/session?session=rest_1'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
+
         self.http_client.fetch(
-          self.get_url('/stubo/api/begin/session?scenario=rest&session=rest_1&mode=playback'), self.stop)                       
+            self.get_url('/stubo/api/begin/session?scenario=rest&session=rest_1&mode=playback'), self.stop)
         response = self.wait()
         self.assertEqual(response.code, 200)
-        
-        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=rest_1'), 
-            self.stop, method='POST', body="", headers={'Stubo-Request-Path' : '/some/content',
-                                               'Stubo-Request-Method': 'GET'})                 
+
+        self.http_client.fetch(self.get_url('/stubo/api/get/response?session=rest_1'),
+                               self.stop, method='POST', body="", headers={'Stubo-Request-Path': '/some/content',
+                                                                           'Stubo-Request-Method': 'GET'})
         response = self.wait()
-        self.assertEqual(response.code, 200)  
+        self.assertEqual(response.code, 200)
         self.assertEqual(response.headers.get("Content-Type"), "application/json")
-        self.assertEqual(response.headers.get("My-App"), "XYZ")                       
+        self.assertEqual(response.headers.get("My-App"), "XYZ")

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1541,15 +1541,15 @@ class TestTracker(Base):
         tracker = self.db.tracker.find_one({'function':'get/response'})
         # minimal or full tracking level items
         self.assertEqual(tracker['function'], "get/response")
-        self.assertTrue(tracker['start_time'] != None)
+        self.assertTrue(tracker['start_time'] is not None)
         self.assertEqual(tracker['return_code'], 200)
-        self.assertTrue(tracker['server'] != None)
-        self.assertTrue(tracker['host'] != None)
+        self.assertTrue(tracker['server'] is not None)
+        self.assertTrue(tracker['host'] is not None)
         self.assertEqual(tracker['request_params']['session'], "first_1")
         self.assertEqual(tracker['scenario'], "first")
-        self.assertTrue(tracker['duration_ms'] != None)
-        self.assertTrue(tracker['remote_ip'] != None)
-        self.assertTrue(tracker['delay'] != None)
+        self.assertTrue(tracker['duration_ms'] is not None)
+        self.assertTrue(tracker['remote_ip'] is not None)
+        self.assertTrue(tracker['delay'] is not None)
         self.assertIn("Hello 2 World this is", tracker['stubo_response'])
 
         # full tracking only 


### PR DESCRIPTION
Updated tests to work with separated export formats. Also:
* A lot of pep8 error fixes
* PyLint error fixes 
* Comparison operations with None changed from "!=" to "is not" 
* Code cleanup of unused imports
* Added few missing assertions in tests

Branch Travis CI status:
![Travis Logo](https://travis-ci.org/rusenask/stubo-app.svg?branch=feature%2Ftests_for_splitted_export_formats)

https://travis-ci.org/rusenask/stubo-app.svg?branch=feature%2Ftests_for_splitted_export_formats

