### PR TITLE
Feature/rename scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@
 language: python
 python:
     - 2.7
+
+cache: pip
   
 install:
     - travis_retry python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 # http://travis-ci.org/#!/Stub-O-Matic/stubo-app
 language: python
+
+cache: pip
+
 python:
     - 2.7
 
-cache: pip
+
   
 install:
     - travis_retry python setup.py install

--- a/docs/pages/api.rst
+++ b/docs/pages/api.rst
@@ -250,7 +250,39 @@ end/sessions
         }
     }
 
-    
+
+put/scenarios
+=============
+
+Scenario names can be changed by providing current scenario name and new name. This operation includes renaming all the
+stubs that belong to this scenario, as well as changing scenario name value in saved sessions. Sessions will be
+transfered to new scenario. During rename procedure - all sessions will be set to dormant mode. Returns status code
+412 if no name or no query is provided. Returns status code 400 if scenario name has illegal characters.
+Scenario name check regex: r'[\w-]*$' - letters, numbers, dashes, underscores
+
+.. code-block:: javascript
+
+    put/scenarios/(?P<scenario_name>[^\/]+) (GET)
+       query args:
+           new_name: new scenario name
+
+    stubo/api/put/scenarios/first?new_name=new_first_scenario_name
+
+    {
+    "Scenarios changed": 1,
+
+    "Remapped sessions": [
+             {
+                 "name": "myscenario_session2"
+             }
+         ],
+    "New name": "localhost:new_first_scenario_name",
+    "Old name": "localhost:first",
+    "Stubs changed": 5,
+    "Pre stubs changed": 0
+    }
+
+
 put/stub
 ========
 

--- a/stubo/model/db.py
+++ b/stubo/model/db.py
@@ -100,6 +100,9 @@ class Scenario(object):
                 {'scenario': name}, {'$set': {'scenario': new_name}}, False, False, None, True)
             try:
                 response['Stubs changed'] = result['nModified']
+            except KeyError:
+                # older versions of mongodb returns 'n' instead of 'nModified'
+                response['Stubs changed'] = result['n']
             except Exception as ex1:
                 # this is probably KeyError, leaving Exception for debugging purposes
                 log.debug("Could not get STUB nModified key, result returned: %s. Error: %s" % (result, ex1))
@@ -113,6 +116,9 @@ class Scenario(object):
                 {'scenario': name}, {'$set': {'scenario': new_name}}, False, False, None, True)
             try:
                 response['Pre stubs changed'] = result['nModified']
+            except KeyError:
+                # older versions of mongodb returns 'n' instead of 'nModified'
+                response['Pre stubs changed'] = result['n']
             except Exception as ex1:
                 log.debug("Could not get PRE STUB nModified key, result returned: %s. Error: %s" % (result, ex1))
         except Exception as ex:
@@ -124,6 +130,9 @@ class Scenario(object):
             result = self.db.scenario.update({'name': name}, {'name': new_name})
             try:
                 response['Scenarios changed'] = result['nModified']
+            except KeyError:
+                # older versions of mongodb returns 'n' instead of 'nModified'
+                response['Scenarios changed'] = result['n']
             except Exception as ex1:
                 log.debug("Could not get SCENARIO nModified key, result returned: %s. Error: %s" % (result, ex1))
         except Exception as ex:

--- a/stubo/model/db.py
+++ b/stubo/model/db.py
@@ -80,6 +80,14 @@ class Scenario(object):
     def insert(self, **kwargs):
         return self.db.scenario.insert(kwargs)
 
+    def change_name(self, name, new_name):
+        result = self.db.scenario_stub.update_many({'scenario': name}, {'$inc': {'scenario': new_name}})
+        matched_stubs = result.matched_count
+        result = self.db.scenario_pre_stub.update_many({'scenario': name}, {'$inc': {'scenario': new_name}})
+        matched_pre_stubs = result.matched_count
+        result = self.db.scenario.update_one({'name': name}, {'$inc': {'name': new_name}})
+
+
     def recorded(self, name=None):
         """
         Calculates scenario recorded date. If name is not supplied - returns a dictionary with scenario name and

--- a/stubo/model/db.py
+++ b/stubo/model/db.py
@@ -98,16 +98,23 @@ class Scenario(object):
         try:
             result = self.db.scenario_stub.update(
                 {'scenario': name}, {'$set': {'scenario': new_name}}, False, False, None, True)
-            response['Stubs changed'] = result['nModified']
+            try:
+                response['Stubs changed'] = result['nModified']
+            except Exception as ex1:
+                # this is probably KeyError, leaving Exception for debugging purposes
+                log.debug("Could not get STUB nModified key, result returned: %s. Error: %s" % (result, ex1))
         except Exception as ex:
-            log.debug("Could not update scenario stub, got error: %s" % ex)
+            log.debug("Could not update scenario stub, got error: %s " % ex)
             response['Stubs changed'] = 0
 
         # updating pre stubs
         try:
             result = self.db.scenario_pre_stub.update(
                 {'scenario': name}, {'$set': {'scenario': new_name}}, False, False, None, True)
-            response['Pre stubs changed'] = result['nModified']
+            try:
+                response['Pre stubs changed'] = result['nModified']
+            except Exception as ex1:
+                log.debug("Could not get PRE STUB nModified key, result returned: %s. Error: %s" % (result, ex1))
         except Exception as ex:
             log.debug("Could not update scenario pre stub, got error: %s" % ex)
             response['Pre stubs changed'] = 0
@@ -115,7 +122,10 @@ class Scenario(object):
         try:
             # updating scenario itself
             result = self.db.scenario.update({'name': name}, {'name': new_name})
-            response['Scenarios changed'] = result['nModified']
+            try:
+                response['Scenarios changed'] = result['nModified']
+            except Exception as ex1:
+                log.debug("Could not get SCENARIO nModified key, result returned: %s. Error: %s" % (result, ex1))
         except Exception as ex:
             log.debug("Could not update scenario, got error: %s" % ex)
             response['Scenarios changed'] = 0

--- a/stubo/model/db.py
+++ b/stubo/model/db.py
@@ -95,18 +95,30 @@ class Scenario(object):
             'Old name': name,
             "New name": new_name
         }
-        result = self.db.scenario_stub.update(
-            {'scenario': name}, {'$set': {'scenario': new_name}}, False, False, None, True)
-        response['Stubs changed'] = result['nModified']
+        try:
+            result = self.db.scenario_stub.update(
+                {'scenario': name}, {'$set': {'scenario': new_name}}, False, False, None, True)
+            response['Stubs changed'] = result['nModified']
+        except Exception as ex:
+            log.debug("Could not update scenario stub, got error: %s" % ex)
+            response['Stubs changed'] = 0
 
         # updating pre stubs
-        result = self.db.scenario_pre_stub.update(
-            {'scenario': name}, {'$set': {'scenario': new_name}}, False, False, None, True)
-        response['Pre stubs changed'] = result['nModified']
+        try:
+            result = self.db.scenario_pre_stub.update(
+                {'scenario': name}, {'$set': {'scenario': new_name}}, False, False, None, True)
+            response['Pre stubs changed'] = result['nModified']
+        except Exception as ex:
+            log.debug("Could not update scenario pre stub, got error: %s" % ex)
+            response['Pre stubs changed'] = 0
 
-        # updating scenario itself
-        result = self.db.scenario.update({'name': name}, {'name': new_name})
-        response['Scenarios changed'] = result['nModified']
+        try:
+            # updating scenario itself
+            result = self.db.scenario.update({'name': name}, {'name': new_name})
+            response['Scenarios changed'] = result['nModified']
+        except Exception as ex:
+            log.debug("Could not update scenario, got error: %s" % ex)
+            response['Scenarios changed'] = 0
 
         return response
 

--- a/stubo/model/db.py
+++ b/stubo/model/db.py
@@ -91,7 +91,10 @@ class Scenario(object):
         # actually want, in our case - the fourth parameter "multi" = True
         # update(spec, document[, upsert=False[,
         #                        manipulate=False[, safe=None[, multi=False[, check_keys=True[, **kwargs]]]]]])
-        response = {}
+        response = {
+            'Old name': name,
+            "New name": new_name
+        }
         result = self.db.scenario_stub.update(
             {'scenario': name}, {'$set': {'scenario': new_name}}, False, False, None, True)
         response['Stubs changed'] = result['nModified']

--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -406,10 +406,10 @@ class PutScenarioHandler(TrackRequest):
         new_scenario_name = RequestHandler.get_query_arguments(self, 'new_name')
         # checking whether scenario name and new scenario name values are supplied
         if new_scenario_name and scenario_name and new_scenario_name != ['']:
-            if re.match(r'[\w-]*$', new_scenario_name[0]):
-                rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name[0])
-            else:
-                self.set_status(400, "Illegal characters supplied. Name provided: %s" % new_scenario_name[0])
+            #if re.match(r'[\w-]*$', new_scenario_name[0]):
+            rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name[0])
+            # else:
+            #     self.set_status(400, "Illegal characters supplied. Name provided: %s" % new_scenario_name[0])
         else:
             self.set_status(412, "Precondition failed: name not supplied")
 

--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -34,6 +34,9 @@ from stubo import version
 from stubo.exceptions import StuboException, exception_response
 from stubo.testing import DummyModel
 
+from handlers_mt import rename_scenario
+
+
 log = logging.getLogger(__name__)
 
 class HandlerFactory(object):
@@ -389,6 +392,22 @@ class GetScenariosHandler(TrackRequest):
         
     def post(self):
         self.get()                       
+class PutScenarioHandler(TrackRequest):
+    """
+    /stubo/api/put/scenarios/(?P<scenario_name>[^\/]+)?new_name=some_new_name
+
+    """
+    def compute_etag(self):
+        return None
+
+    def get(self, scenario_name):
+        new_scenario_name = RequestHandler.get_query_arguments(self, 'new_name')
+        # checking whether scenario name and new scenario name values are supplied
+        if new_scenario_name and scenario_name:
+            rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name)
+
+        else:
+            self.set_status(412, "Precondition failed: name not supplied")
 
 class GetStubCountHandler(TrackRequest):
     

--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -406,7 +406,7 @@ class PutScenarioHandler(TrackRequest):
         new_scenario_name = RequestHandler.get_query_arguments(self, 'new_name')
         # checking whether scenario name and new scenario name values are supplied
         if new_scenario_name and scenario_name:
-            rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name)
+            rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name[0])
 
         else:
             self.set_status(412, "Precondition failed: name not supplied")

--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -406,10 +406,10 @@ class PutScenarioHandler(TrackRequest):
         new_scenario_name = RequestHandler.get_query_arguments(self, 'new_name')
         # checking whether scenario name and new scenario name values are supplied
         if new_scenario_name and scenario_name and new_scenario_name != ['']:
-            #if re.match(r'[\w-]*$', new_scenario_name[0]):
-            rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name[0])
-            # else:
-            #     self.set_status(400, "Illegal characters supplied. Name provided: %s" % new_scenario_name[0])
+            if re.match(r'[\w-]*$', new_scenario_name[0]):
+                rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name[0])
+            else:
+                self.set_status(400, "Illegal characters supplied. Name provided: %s" % new_scenario_name[0])
         else:
             self.set_status(412, "Precondition failed: name not supplied")
 

--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -8,7 +8,7 @@ import logging
 import datetime
 import csv
 from StringIO import StringIO
-
+import re
 from tornado.web import RequestHandler, asynchronous
 import tornado.ioloop
 from plop.collector import Collector
@@ -406,8 +406,10 @@ class PutScenarioHandler(TrackRequest):
         new_scenario_name = RequestHandler.get_query_arguments(self, 'new_name')
         # checking whether scenario name and new scenario name values are supplied
         if new_scenario_name and scenario_name and new_scenario_name != ['']:
-            rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name[0])
-
+            if re.match(r'[\w-]*$', new_scenario_name[0]):
+                rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name[0])
+            else:
+                self.set_status(400, "Illegal characters supplied. Name provided: %s" % new_scenario_name[0])
         else:
             self.set_status(412, "Precondition failed: name not supplied")
 

--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -405,7 +405,7 @@ class PutScenarioHandler(TrackRequest):
     def get(self, scenario_name):
         new_scenario_name = RequestHandler.get_query_arguments(self, 'new_name')
         # checking whether scenario name and new scenario name values are supplied
-        if new_scenario_name and scenario_name:
+        if new_scenario_name and scenario_name and new_scenario_name != ['']:
             rename_scenario(self, scenario_name=scenario_name, new_name=new_scenario_name[0])
 
         else:

--- a/stubo/service/handlers.py
+++ b/stubo/service/handlers.py
@@ -15,12 +15,12 @@ from plop.collector import Collector
 import yappi
 
 from stubo.service.handlers_mt import (
-    export_stubs_request, list_stubs_request, 
+    export_stubs_request, list_stubs_request,
     command_handler_request, command_handler_form_request, delay_policy_request,
     stub_count_request, begin_session_request, end_session_request,
     put_stub_request, get_response_request, delete_stubs_request,
     status_request, manage_request, tracker_request,
-    tracker_detail_request, get_delay_policy_request, 
+    tracker_detail_request, get_delay_policy_request,
     delete_delay_policy_request, put_module_request,
     delete_module_request, list_module_request, delete_modules_request,
     put_bookmark_request, get_bookmark_request, jump_bookmark_request,
@@ -52,99 +52,99 @@ class BeginSessionHandler(TrackRequest):
     def get(self):
         self.post()
 
-    def post(self): 
+    def post(self):
         begin_session_request(self)
 
 class EndSessionHandler(TrackRequest):
-    
+
     def get(self):
         self.post()
 
     def post(self):
         end_session_request(self)
-        
+
 class EndSessionsHandler(TrackRequest):
-    
+
     def get(self):
         self.post()
 
     def post(self):
-        end_sessions_request(self)        
+        end_sessions_request(self)
 
 class GetResponseHandler(TrackRequest):
-    
+
     def post(self):
         get_response_request(self)
-        
+
     def get(self):
         self.set_status(405)
         emsg = 'Not allowed to use HTTP GET for get/response, use POST instead.'
-        response = dict(version=version, error=dict(code=404, message=emsg))         
+        response = dict(version=version, error=dict(code=404, message=emsg))
         self.write(response)
         self.track.stubo_response = response
-        self.finish()        
+        self.finish()
 
 class DeleteStubsHandler(TrackRequest):
-    
+
     def compute_etag(self):
         return None
-    
+
     def get(self):
         self.post()
-        
+
     def post(self):
-        delete_stubs_request(self)  
+        delete_stubs_request(self)
 
 class PutStubHandler(TrackRequest):
-    
+
     def get(self):
         self.set_status(405)
         emsg = 'Not allowed to use HTTP GET for put/stub, use POST instead.'
-        response = dict(version=version, error=dict(code=404, message=emsg))       
+        response = dict(version=version, error=dict(code=404, message=emsg))
         self.write(response)
         self.track.stubo_response = response
-        self.finish()    
-    
+        self.finish()
+
     def post(self):
         put_stub_request(self)
-        
+
 class PutModuleHandler(TrackRequest):
-    
+
     def get(self):
         self.post()
-        
-    def post(self):
-        put_module_request(self)  
 
-     
+    def post(self):
+        put_module_request(self)
+
+
 class DeleteModuleHandler(TrackRequest):
     """  Delete named user exit module 
     """
-    
+
     def get(self):
         self.post()
-        
+
     def post(self):
-        delete_module_request(self) 
-        
+        delete_module_request(self)
+
 class DeleteModulesHandler(TrackRequest):
     """ Delete all user exit modules 
     """
-    
+
     def get(self):
         self.post()
-        
+
     def post(self):
-        delete_modules_request(self)           
-        
+        delete_modules_request(self)
+
 class GetModuleListHandler(TrackRequest):
-        
+
     def get(self):
         self.post()
-            
+
     def post(self):
-        list_module_request(self) 
-        
+        list_module_request(self)
+
 class PutBookmarkHandler(TrackRequest):
     '''/api/put/bookmark?session=joe&session=mary&name=mary_and_joe_fri_2pm
     Note the sessions need to be in playback mode.
@@ -170,69 +170,69 @@ class PutBookmarkHandler(TrackRequest):
 11) "mary:f2022a5438c084278ec23c400b2a0551203b8d0320e071ff981f9ec4"
 12) "[[\"8a63cd9b720c32b82835c0a30e8d8799626ba3768ebf6136f4b1e1b8\", \"4cff130013f4833e81613b3a44d669040b33c9030e312f339e0b5661\", \"c8c48e8fcc8d1784cfa92745895595415d35b51725e8b8ead796cd4d\"], \"\", \"2013-10-25\", \"2013-10-25\", {}]"   
     '''
-    
+
     def get(self):
         self.post()
-            
+
     def post(self):
         put_bookmark_request(self)
-        
+
 class GetBookmarksHandler(TrackRequest):
-    
+
     def get(self):
         self.post()
-            
+
     def post(self):
-        get_bookmark_request(self)    
-        
+        get_bookmark_request(self)
+
 class JumpBookmarkHandler(TrackRequest):
-    
+
     def get(self):
         self.post()
-            
+
     def post(self):
         jump_bookmark_request(self)
-        
+
 class DeleteBookmarkHandler(TrackRequest):
-    
+
     def get(self):
         self.post()
-            
+
     def post(self):
-        delete_bookmark_request(self)  
-        
+        delete_bookmark_request(self)
+
 class ImportBookmarksHandler(TrackRequest):
-    
+
     def get(self):
         self.post()
-            
+
     def post(self):
         import_bookmarks_request(self)
-        
+
 class BookmarkHandler(RequestHandler):
-    
+
     def compute_etag(self):
         return None
-     
+
     def get(self):
-        get_bookmarks_request(self)  
-        
+        get_bookmarks_request(self)
+
     def post(self):
         self.get()
 
 class ViewTrackerHandler(RequestHandler):
-    
+
     def compute_etag(self):
         return None
-    
+
     def get(self):
         tracker_request(self)
 
 class ViewATrackerHandler(RequestHandler):
-    
-    def get(self, tracker_id, **kwargs):        
+
+    def get(self, tracker_id, **kwargs):
         tracker_detail_request(self, tracker_id)
-    
+
 class HomeHandler(RequestHandler):
     def get(self):
         response = self.render_string("home.html", page_title='Stub-O-Matic')
@@ -246,23 +246,23 @@ class DocsHandler(RequestHandler):
                       permanent=True)
 
 class GetVersionHandler(TrackRequest):
-        
+
     def get(self):
         response = {'version' : self.settings['stubo_version']}
         self.write(response)
         self.track.stubo_response = response
         self.finish()
-        
-    def post(self): 
-        self.get()    
+
+    def post(self):
+        self.get()
 
 class StuboCommandHandler(TrackRequest):
-    
+
     def compute_etag(self):
         # override tornado default which will return a 304 (not modified)
         # if the response contents of a GET call with the same signature matches
         return None
-    
+
     @tornado.gen.coroutine
     def get(self):
         stubo_response = dict(version=version)
@@ -271,127 +271,129 @@ class StuboCommandHandler(TrackRequest):
             cmd_file_url = self.get_argument('cmdfile', None)
             if not cmd_file_url:
                 # LEGACY
-                cmd_file_url = self.get_argument('cmdFile', None)    
+                cmd_file_url = self.get_argument('cmdFile', None)
             if not cmd_file_url:
                 raise exception_response(400,
                     title="'cmdfile' parameter not supplied.")
-      
+
             request = DummyModel(protocol=self.request.protocol,
                                  host=self.request.host,
                                  arguments=self.request.arguments)
-            stubo_response = yield executor.submit(command_handler_request, 
+            stubo_response = yield executor.submit(command_handler_request,
                                                    cmd_file_url,
-                                                   request, 
-                                                   self.settings['static_path'])      
-        except StuboException, err: 
-            stubo_response['error'] = dict(code=err.code, message=err.title)        
+                                                   request,
+                                                   self.settings['static_path'])
+        except StuboException, err:
+            stubo_response['error'] = dict(code=err.code, message=err.title)
             if hasattr(err, 'traceback'):
-                stubo_response['error']['traceback'] = err.traceback  
-            self.set_status(err.code)  
-        except Exception, e: 
+                stubo_response['error']['traceback'] = err.traceback
+            self.set_status(err.code)
+        except Exception, e:
             status = self.get_status()
-            if not status or status == 200: 
+            if not status or status == 200:
                 # if error has not been or set to ok set it to internal server error
-                stubo_response['error'] = dict(code=500, message=str(e)) 
+                stubo_response['error'] = dict(code=500, message=str(e))
                 self.set_status(500)
             else:
                 stubo_response['error'] = dict(code=status, message=str(e))
             if hasattr(e, 'traceback'):
                 stubo_response['error']['traceback'] = e.traceback
-                            
-        self.write(stubo_response) 
-        self.set_header('x-stubo-version', version)    
-        self.finish()   
-       
-       
+
+        self.write(stubo_response)
+        self.set_header('x-stubo-version', version)
+        self.finish()
+
+
     @tornado.gen.coroutine
-    def post(self): 
+    def post(self):
         stubo_response = dict(version=version)
         try:
             executor = self.settings['process_executor']
             cmd_file_url = self.get_argument('cmdfile', None)
             if not cmd_file_url:
                 # LEGACY
-                cmd_file_url = self.get_argument('cmdFile', None)    
+                cmd_file_url = self.get_argument('cmdFile', None)
             if not cmd_file_url:
                 raise exception_response(400,
                     title="'cmdfile' parameter not supplied.")
-      
+
             request = DummyModel(protocol=self.request.protocol,
                                  host=self.request.host,
                                  arguments=self.request.arguments)
-            stubo_response = yield executor.submit(command_handler_request, 
+            stubo_response = yield executor.submit(command_handler_request,
                                                    cmd_file_url,
-                                                   request, 
-                                                   self.settings['static_path'])      
-        except StuboException, err: 
-            stubo_response['error'] = dict(code=err.code, message=err.title)        
+                                                   request,
+                                                   self.settings['static_path'])
+        except StuboException, err:
+            stubo_response['error'] = dict(code=err.code, message=err.title)
             if hasattr(err, 'traceback'):
-                stubo_response['error']['traceback'] = err.traceback  
-            self.set_status(err.code)  
-        except Exception, e: 
+                stubo_response['error']['traceback'] = err.traceback
+            self.set_status(err.code)
+        except Exception, e:
             status = self.get_status()
-            if not status or status == 200: 
+            if not status or status == 200:
                 # if error has not been or set to ok set it to internal server error
-                stubo_response['error'] = dict(code=500, message=str(e)) 
+                stubo_response['error'] = dict(code=500, message=str(e))
                 self.set_status(500)
             else:
                 stubo_response['error'] = dict(code=status, message=str(e))
             if hasattr(e, 'traceback'):
                 stubo_response['error']['traceback'] = e.traceback
-            
-        self.write(stubo_response) 
-        self.set_header('x-stubo-version', version)    
-        self.finish()           
-                 
+
+        self.write(stubo_response)
+        self.set_header('x-stubo-version', version)
+        self.finish()
+
 class StuboCommandHandlerHTML(TrackRequest):
-    
+
     def compute_etag(self):
         # override tornado default which will return a 304 (not modified)
         # if the response contents of a GET call with the same signature matches
         return None
-        
+
     def get(self):
         # handle form from the GUI (/manage page) 
         command_handler_form_request(self)
-               
+
     def post(self):
-        self.get()     
-     
+        self.get()
+
 class GetStubExportHandler(TrackRequest):
-        
+
     def get(self):
         export_stubs_request(self)
-        
+
     def post(self):
-        self.get()    
-     
+        self.get()
+
 class GetStubListHandlerHTML(RequestHandler):
-        
+
     def get(self):
-        list_stubs_request(self, html=True)  
-        
+        list_stubs_request(self, html=True)
+
 class GetStubListHandler(TrackRequest):
-    
+
     def compute_etag(self):
         return None
-        
+
     def get(self):
-        list_stubs_request(self) 
-        
+        list_stubs_request(self)
+
     def post(self):
-        self.get()      
-        
+        self.get()
+
 class GetScenariosHandler(TrackRequest):
-    
+
     def compute_etag(self):
         return None
-        
+
     def get(self):
-        list_scenarios_request(self)   
-        
+        list_scenarios_request(self)
+
     def post(self):
-        self.get()                       
+        self.get()
+
+
 class PutScenarioHandler(TrackRequest):
     """
     /stubo/api/put/scenarios/(?P<scenario_name>[^\/]+)?new_name=some_new_name
@@ -409,104 +411,105 @@ class PutScenarioHandler(TrackRequest):
         else:
             self.set_status(412, "Precondition failed: name not supplied")
 
+
 class GetStubCountHandler(TrackRequest):
-    
+
     def compute_etag(self):
         return None
 
     def get(self):
-        stub_count_request(self) 
-        
-    def post(self):
-        self.get()       
-        
-class GetStatsHandler(TrackRequest):
-    
-    def compute_etag(self):
-        return None
+        stub_count_request(self)
 
-    def get(self):
-        stats_request(self) 
-        
-    def post(self):
-        self.get()              
-
-class PutDelayPolicyHandler(TrackRequest):
-        
-    def get(self):
-        self.post()
-         
-    def post(self):
-        delay_policy_request(self)  
-        
-class PutSettingHandler(TrackRequest):
-        
-    def get(self):
-        self.post()
-         
-    def post(self):
-        put_setting_request(self)   
-        
-class GetSettingHandler(RequestHandler):
-        
-    def get(self):
-        self.post()
-         
-    def post(self):
-        get_setting_request(self)                    
-        
-class GetDelayPolicyHandler(TrackRequest):
-        
-    def get(self):
-        get_delay_policy_request(self)  
-         
     def post(self):
         self.get()
-                
-class DeleteDelayPolicyHandler(TrackRequest):
-        
-    def get(self):
-        self.post()
-         
-    def post(self):
-        delete_delay_policy_request(self)                   
-   
-class GetStatusHandler(RequestHandler):
-    
+
+class GetStatsHandler(TrackRequest):
+
     def compute_etag(self):
         return None
 
     def get(self):
-        status_request(self) 
-        
-    def post(self): 
-        self.get()        
-        
+        stats_request(self)
+
+    def post(self):
+        self.get()
+
+class PutDelayPolicyHandler(TrackRequest):
+
+    def get(self):
+        self.post()
+
+    def post(self):
+        delay_policy_request(self)
+
+class PutSettingHandler(TrackRequest):
+
+    def get(self):
+        self.post()
+
+    def post(self):
+        put_setting_request(self)
+
+class GetSettingHandler(RequestHandler):
+
+    def get(self):
+        self.post()
+
+    def post(self):
+        get_setting_request(self)
+
+class GetDelayPolicyHandler(TrackRequest):
+
+    def get(self):
+        get_delay_policy_request(self)
+
+    def post(self):
+        self.get()
+
+class DeleteDelayPolicyHandler(TrackRequest):
+
+    def get(self):
+        self.post()
+
+    def post(self):
+        delete_delay_policy_request(self)
+
+class GetStatusHandler(RequestHandler):
+
+    def compute_etag(self):
+        return None
+
+    def get(self):
+        status_request(self)
+
+    def post(self):
+        self.get()
+
 class AnalyticsHandler(RequestHandler):
 
     def get(self):
         analytics_request(self)
 
 class ManageHandler(RequestHandler):
-     
+
     def get(self):
         manage_request(self)
 
 class ProfileHandler(RequestHandler):
-    
+
     PROF_COLUMNS = (
         'name',
-        'n', 
+        'n',
         'tsub',
-        'ttot',     
+        'ttot',
         'tavg'
     )
-    
+
     def __init__(self, application, request, **kwargs):
-        super(ProfileHandler, self).__init__(application, request, **kwargs) 
+        super(ProfileHandler, self).__init__(application, request, **kwargs)
         self.interval = 60
-        self.limit = 100 
-    
+        self.limit = 100
+
     @asynchronous
     def get(self):
         self.interval = int(self.get_argument('interval', self.interval))
@@ -516,16 +519,16 @@ class ProfileHandler(RequestHandler):
         yappi.start()
         tornado.ioloop.IOLoop.instance().add_timeout(
             datetime.timedelta(seconds=self.interval), self.finish_profile)
-                                      
+
     def finish_profile(self):
         msg = 'stop profile using interval={0}'.format(self.interval)
         log.debug(msg)
         fd = StringIO()
         out_csv = csv.DictWriter(fd, self.PROF_COLUMNS)
-        out_csv.writerow(dict([(name, name) for name in self.PROF_COLUMNS])) 
+        out_csv.writerow(dict([(name, name) for name in self.PROF_COLUMNS]))
         stats = yappi.get_func_stats()
         for row in stats:
-            out_csv.writerow(dict(name=str(row[0]), n=str(row[1]), 
+            out_csv.writerow(dict(name=str(row[0]), n=str(row[1]),
                                   tsub=str(row[2]), ttot=str(row[3]),
                                   tavg=str(row[4])))
         yappi.stop()
@@ -535,22 +538,22 @@ class ProfileHandler(RequestHandler):
         fd.seek(0)
         now = datetime.datetime.utcnow()
         report_name = 'prof-report-%s.csv' % (now.strftime('%y%m%d.%H%M'))
-        body = fd.getvalue()    
+        body = fd.getvalue()
         self.write(body)
         self.set_header('Content-type', 'text/csv')
-        self.set_header('Content-disposition', 
-                        'attachment;filename=%s' % report_name)      
+        self.set_header('Content-disposition',
+                        'attachment;filename=%s' % report_name)
         self.finish()
 
 
 class PlopProfileHandler(RequestHandler):
-    
+
     def __init__(self, application, request, **kwargs):
-        super(PlopProfileHandler, self).__init__(application, request, **kwargs) 
+        super(PlopProfileHandler, self).__init__(application, request, **kwargs)
         self.interval = 60
         self.output = '/tmp/plop.out'
         self.collector = Collector()
-        
+
     @asynchronous
     def get(self):
         self.interval = int(self.get_argument('interval', self.interval))
@@ -558,7 +561,7 @@ class PlopProfileHandler(RequestHandler):
         self.collector.start()
         tornado.ioloop.IOLoop.instance().add_timeout(datetime.timedelta(
             seconds=self.interval), self.finish_profile)
-                                      
+
     def finish_profile(self):
         log.debug('stop profile using interval={0} and output={1}'.format(
             self.interval, self.output))

--- a/stubo/service/handlers_mt.py
+++ b/stubo/service/handlers_mt.py
@@ -219,8 +219,9 @@ def rename_scenario(handler, scenario_name, new_name):
     scenario_obj = scenario.get(full_scenario_name)
     # checking if scenario exist, if not - quit
     if scenario_obj is None:
-        handler.set_status(404)
-        response['data'] = "Scenario not found. Name provided: {0}, host checked: {1}.".format(scenario_name, host)
+        handler.set_status(400)
+        handler.track.scenario = scenario_name
+        response['error'] = "Scenario not found. Name provided: {0}, host checked: {1}.".format(scenario_name, host)
         return response
 
     # renaming scenario and all stubs, getting a dict with results

--- a/stubo/service/handlers_mt.py
+++ b/stubo/service/handlers_mt.py
@@ -210,18 +210,21 @@ def rename_scenario(handler, scenario_name, new_name):
     scenario = Scenario()
     # getting hostname
     host = handler.get_argument('host', get_hostname(handler.request))
-    # getting object
-    scenario_obj = scenario.get("{0}:{1}".format(host, scenario_name))
+    # full names hostname:scenario_name
+    full_scenario_name = "{0}:{1}".format(host, scenario_name)
+    new_full_scenario_name = "{0}:{1}".format(host, new_name)
+    # getting scenario object
+    scenario_obj = scenario.get(full_scenario_name)
     # checking if scenario exist, if not - quit
     if scenario_obj is None:
         handler.set_status(404)
         response['data'] = "Scenario not found. Name provided: {0}, host checked: {1}.".format(scenario_name, host)
         return response
 
-    import pdb
-    pdb.set_trace()
-    # do stuff here
-    pass
+    # renaming scenario and all stubs, getting a dict with results
+    response = scenario.change_name(full_scenario_name, new_full_scenario_name)
+
+    return response
 
 
 @stubo_async    

--- a/stubo/service/handlers_mt.py
+++ b/stubo/service/handlers_mt.py
@@ -191,7 +191,39 @@ def list_scenarios_request(handler):
 def stub_count_request(handler):
     host = handler.get_argument('host', get_hostname(handler.request))
     return stub_count(host, handler.get_argument('scenario', None))
-    
+
+from stubo.model.db import Scenario
+
+@stubo_async
+def rename_scenario(handler, scenario_name, new_name):
+    """
+    Renames specified scenario, renames Stubs, reloads cache
+    :param handler: TrackRequest handler
+    :param scenario_name: <string> scenario name
+    :param new_name: <string> new scenario name
+    :return: <tuple> containing status code and message that will be returned
+    """
+    response = {
+        'version': version
+    }
+
+    scenario = Scenario()
+    # getting hostname
+    host = handler.get_argument('host', get_hostname(handler.request))
+    # getting object
+    scenario_obj = scenario.get("{0}:{1}".format(host, scenario_name))
+    # checking if scenario exist, if not - quit
+    if scenario_obj is None:
+        handler.set_status(404)
+        response['data'] = "Scenario not found. Name provided: {0}, host checked: {1}.".format(scenario_name, host)
+        return response
+
+    import pdb
+    pdb.set_trace()
+    # do stuff here
+    pass
+
+
 @stubo_async    
 def delete_stubs_request(handler):
     return delete_stubs(handler, 

--- a/stubo/service/run_stubo.py
+++ b/stubo/service/run_stubo.py
@@ -148,6 +148,7 @@ class TornadoManager(object):
             ("/stubo/api/get/stubcount", "GetStubCountHandler"),
             ("/stubo/api/get/stublist", "GetStubListHandler"),
             ("/stubo/api/get/scenarios", "GetScenariosHandler"),
+            ("/stubo/api/put/scenarios/(?P<scenario_name>[^\/]+)", "PutScenarioHandler"),
             ("/stubo/api/get/export", "GetStubExportHandler"),
             ("/stubo/api/get/stats", "GetStatsHandler"),
             ("/stubo/api/put/delay_policy", "PutDelayPolicyHandler"),

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1315,6 +1315,16 @@ class TestSession(Base):
         self.assertTrue('Scenario not found' in response_dict['error'])
         self.assertEqual(response.code, 400)
 
+    def test_change_name_without_name(self):
+        """
+
+        Test scenario name change when
+        """
+        self.http_client.fetch(
+            self.get_url('/stubo/api/put/scenarios/some_name'), self.stop)
+        response = self.wait()
+        self.assertEqual(response.code, 412)
+        self.assertTrue('Precondition failed: name not supplied' in response.error.message)
 
     def test_end_session(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1347,6 +1347,10 @@ class TestSession(Base):
 
     def test_change_name_with_illegalcharacters(self):
         # providing '' to new change
+        """
+
+        Passes illegal characters to stubo to check for response code. Expected response code - 400
+        """
         name = '@#$name'
         self.http_client.fetch(
             self.get_url('/stubo/api/put/scenarios/some_name?new_name=%s' % name), self.stop)

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 import json
 from stubo.testing import Base
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class TestPutDelay(Base):
@@ -1288,11 +1291,13 @@ class TestSession(Base):
         :param scenario_old_name: <string> without host, only scenario key name
         :param scenario_new_name: <string> without host, only scenario key name
         """
+        self.assertIsNotNone(scenario_old_name, "Old scenario name is none!")
+        self.assertIsNotNone(scenario_new_name, "New scenario name is none!")
         self.http_client.fetch(
             self.get_url('/stubo/api/put/scenarios/%s?new_name=%s' % (scenario_old_name, scenario_new_name)), self.stop)
         response = self.wait()
         if response.code == 500:
-            print(response.error)
+            log.debug(response)
         self.assertEqual(response.code, 200, response.error)
         response_dict = json.loads(response.body)
         # checking if stub was found and updated

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1291,7 +1291,7 @@ class TestSession(Base):
         self.http_client.fetch(
             self.get_url('/stubo/api/put/scenarios/%s?new_name=%s' % (scenario_old_name, scenario_new_name)), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200, response.error.message)
+        self.assertEqual(response.code, 200, response.error)
         response_dict = json.loads(response.body)
         # checking if stub was found and updated
         self.assertEqual(response_dict['Stubs changed'], 1)
@@ -1345,7 +1345,7 @@ class TestSession(Base):
         self.assertEqual(response.code, 412)
         self.assertTrue('Precondition failed: name not supplied' in response.error.message)
 
-    def test_change_name_with_illegalcharacters(self):
+    def _test_change_name_with_illegalcharacters(self):
         # providing '' to new change
         """
 

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1257,7 +1257,7 @@ class TestSession(Base):
         self.assertTrue('first_1' in response.body)
 
         # insert stub
-        self._test_stub_insert(scenario_old_name)
+        self._test_stub_insert()
 
         # change scenario name
         scenario_new_name = 'first_new_name'
@@ -1269,7 +1269,7 @@ class TestSession(Base):
         # check if the session is still attached to this scenario
         self.assertTrue('first_1' in response.body)
 
-    def _test_stub_insert(self, scenario_name):
+    def _test_stub_insert(self):
         # setting session to record mode
         """
 
@@ -1325,6 +1325,22 @@ class TestSession(Base):
         response = self.wait()
         self.assertEqual(response.code, 412)
         self.assertTrue('Precondition failed: name not supplied' in response.error.message)
+
+    def test_change_name_blank(self):
+        # creating new scenario and session, setting record mode to prepare it for stub insertion
+        scenario_old_name = 'first_old_name'
+        self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
+                                            '%s&session=first_change_name&mode=record' % scenario_old_name), self.stop)
+        response = self.wait()
+        self.assertEqual(response.code, 200)
+
+        # providing '' to new change
+        self.http_client.fetch(
+            self.get_url('/stubo/api/put/scenarios/%s?new_name=' % scenario_old_name), self.stop)
+        response = self.wait()
+        self.assertEqual(response.code, 412)
+        self.assertTrue('Precondition failed: name not supplied' in response.error.message)
+
 
     def test_end_session(self):
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1318,7 +1318,7 @@ class TestSession(Base):
     def test_change_name_without_name(self):
         """
 
-        Test scenario name change when
+        Test scenario name change when query is missing
         """
         self.http_client.fetch(
             self.get_url('/stubo/api/put/scenarios/some_name'), self.stop)
@@ -1327,8 +1327,12 @@ class TestSession(Base):
         self.assertTrue('Precondition failed: name not supplied' in response.error.message)
 
     def test_change_name_blank(self):
+        """
+
+        Test scenario name change when new name is empty
+        """
         # creating new scenario and session, setting record mode to prepare it for stub insertion
-        scenario_old_name = 'first_old_name'
+        scenario_old_name = 'first_old_name_1'
         self.http_client.fetch(self.get_url('/stubo/api/begin/session?scenario='
                                             '%s&session=first_change_name&mode=record' % scenario_old_name), self.stop)
         response = self.wait()
@@ -1340,6 +1344,15 @@ class TestSession(Base):
         response = self.wait()
         self.assertEqual(response.code, 412)
         self.assertTrue('Precondition failed: name not supplied' in response.error.message)
+
+    def test_change_name_with_illegalcharacters(self):
+        # providing '' to new change
+        name = '@#$name'
+        self.http_client.fetch(
+            self.get_url('/stubo/api/put/scenarios/some_name?new_name=%s' % name), self.stop)
+        response = self.wait()
+        self.assertEqual(response.code, 400)
+        self.assertTrue('Illegal characters supplied' in response.error.message)
 
 
     def test_end_session(self):

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1291,7 +1291,7 @@ class TestSession(Base):
         self.http_client.fetch(
             self.get_url('/stubo/api/put/scenarios/%s?new_name=%s' % (scenario_old_name, scenario_new_name)), self.stop)
         response = self.wait()
-        self.assertEqual(response.code, 200)
+        self.assertEqual(response.code, 200, response.error.message)
         response_dict = json.loads(response.body)
         # checking if stub was found and updated
         self.assertEqual(response_dict['Stubs changed'], 1)

--- a/stubo/tests/integration/test_api.py
+++ b/stubo/tests/integration/test_api.py
@@ -1291,6 +1291,8 @@ class TestSession(Base):
         self.http_client.fetch(
             self.get_url('/stubo/api/put/scenarios/%s?new_name=%s' % (scenario_old_name, scenario_new_name)), self.stop)
         response = self.wait()
+        if response.code == 500:
+            print(response.error)
         self.assertEqual(response.code, 200, response.error)
         response_dict = json.loads(response.body)
         # checking if stub was found and updated
@@ -1345,7 +1347,7 @@ class TestSession(Base):
         self.assertEqual(response.code, 412)
         self.assertTrue('Precondition failed: name not supplied' in response.error.message)
 
-    def _test_change_name_with_illegalcharacters(self):
+    def test_change_name_with_illegalcharacters(self):
         # providing '' to new change
         """
 


### PR DESCRIPTION
New feature - API call to change scenario name. Docs are updated, in short, usage is like this:
variables:
old_scenario_name
new_scenario_name
curl -v 127.0.0.1:8001/stubo/api/put/scenarios/{{old_scenario_name}}?new_name={{new_scenario_name}}

Build status:
[![Build Status](https://travis-ci.org/rusenask/stubo-app.svg?branch=feature%2Frename_scenario)](https://travis-ci.org/rusenask/stubo-app)