### PR TITLE
Feature/query timer

### DIFF
--- a/stubo/model/db.py
+++ b/stubo/model/db.py
@@ -8,6 +8,7 @@ from bson.objectid import ObjectId
 from stubo.utils import asbool
 from stubo.model.stub import Stub
 import hashlib
+import time
 
 default_env = {
     'port': 27017,
@@ -151,6 +152,7 @@ class Scenario(object):
         :param name: optional parameter to get recorded date for specific scenario
         :return: <dict> - if name is not supplied, <string> with date - if scenario name supplied.
         """
+        start_time = time.time()
         pipeline = [
             {'$group': {
                 '_id': '$scenario',
@@ -167,6 +169,9 @@ class Scenario(object):
         # using dict comprehension to form a new dict for fast access to elements
         result_dict = {x['_id']: x['recorded'] for x in result}
 
+        # finish time
+        finish_time = time.time()
+        log.info("Recorded calculated in %s ms" % int((finish_time-start_time)*1000))
         # if name is provided - return only single recorded date for specific scenario.
         if name:
             scenario_recorded = None
@@ -191,9 +196,12 @@ class Scenario(object):
         :param name: optional parameter to get size of specific scenario
         :return: <dict> - if name is not supplied, <int> - if scenario name supplied.
         """
+        start_time = time.time()
         pipeline = [{'$group': {
             '_id': '$scenario',
-            'size': {'$sum': '$space_used'}}}]
+            'size': {'$sum': {'$divide': ['$space_used', 1024]}}
+                                }
+                    }]
 
         # use the pipe to calculate scenario sizes
         try:
@@ -207,6 +215,9 @@ class Scenario(object):
         # using dict comprehension to form a new dict for fast access to elements
         result_dict = {x['_id']: x['size'] for x in result}
 
+        # finish time
+        finish_time = time.time()
+        log.info("Sizes calculated in %s ms" % int((finish_time-start_time)*1000))
         # if name is provided - return only single size for specific scenario.
         if name:
             scenario_size = None

--- a/stubo/static/templates/manage.html
+++ b/stubo/static/templates/manage.html
@@ -37,7 +37,6 @@
                     title="Enter line separated commands.">
               <textarea id="manage-exe-commands" class="form-control"  name="cmds"  placeholder="delete/stubs?scenario=foo"></textarea>    
           </div>
-       </div> 
     </form>
     
    </div>


### PR DESCRIPTION
further updates to /manage - solved issue when having > 10GB database, ~100 000 items in tracker /manage page could be loading for ~20 seconds due to poor search. Now added indexes to tracker collection. Also, moved "human size" calculations to mongo aggregation framework.

2015-07-15 14:25:02,946 INFO  [stubo.model.db][6391:Thread-2] Sizes calculated in 90 ms
2015-07-15 14:25:02,991 INFO  [stubo.model.db][6391:Thread-2] Recorded calculated in 44 ms
2015-07-15 14:25:03,866 INFO  [tornado.access][6391:MainThread] 304 GET /manage?all_hosts=false (::1) 1012.25ms

Should completely solve /manage page problems. 